### PR TITLE
fix: update translation keys to use shortened prefix in component tem…

### DIFF
--- a/src/components/ClientsOnline.vue
+++ b/src/components/ClientsOnline.vue
@@ -3,31 +3,31 @@
     <table class="FormTable SettingsTable tableApi_table">
       <thead>
         <tr>
-          <td colspan="3">{{ $t('components.ClientsOnline.title') }}</td>
+          <td colspan="3">{{ $t('com.ClientsOnline.title') }}</td>
         </tr>
       </thead>
       <tbody v-if="logsEnabled">
         <tr class="row_title">
-          <th>{{ $t('components.ClientsOnline.label_ip') }}</th>
-          <th>{{ $t('components.ClientsOnline.label_client') }}</th>
+          <th>{{ $t('com.ClientsOnline.label_ip') }}</th>
+          <th>{{ $t('com.ClientsOnline.label_client') }}</th>
         </tr>
         <tr v-for="client in clients" :key="client.ip" class="data_tr">
           <td>
-            <span class="label label-success">{{ $t('components.ClientsOnline.online') }}</span>
+            <span class="label label-success">{{ $t('com.ClientsOnline.online') }}</span>
             {{ client.ip }}
           </td>
           <td>{{ client.email.filter((email) => email).join(', ') }}</td>
         </tr>
         <tr v-if="!clients.length" class="data_tr">
-          <td colspan="3" style="color: #ffcc00">{{ $t('components.ClientsOnline.noone_is_online') }}</td>
+          <td colspan="3" style="color: #ffcc00">{{ $t('com.ClientsOnline.noone_is_online') }}</td>
         </tr>
       </tbody>
       <tbody v-else>
         <tr class="data_tr">
           <td colspan="3" style="color: #ffcc00">
-            {{ $t('components.ClientsOnline.message_logs') }}
+            {{ $t('com.ClientsOnline.message_logs') }}
             <br />
-            <input class="button_gen button_gen_small" type="button" :value="$t('components.ClientsOnline.enable_logs')" @click.prevent="enable_logs" />
+            <input class="button_gen button_gen_small" type="button" :value="$t('com.ClientsOnline.enable_logs')" @click.prevent="enable_logs" />
           </td>
         </tr>
       </tbody>

--- a/src/components/Dns.vue
+++ b/src/components/Dns.vue
@@ -3,16 +3,16 @@
     <thead>
       <tr>
         <td colspan="2">
-          {{ $t('components.Dns.title') }}
-          <hint v-html="$t('components.Dns.hint_title')"></hint>
+          {{ $t('com.Dns.title') }}
+          <hint v-html="$t('com.Dns.hint_title')"></hint>
         </td>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th>
-          {{ $t('components.Dns.label_tag') }}
-          <hint v-html="$t('components.Dns.hint_tag')"></hint>
+          {{ $t('com.Dns.label_tag') }}
+          <hint v-html="$t('com.Dns.hint_tag')"></hint>
         </th>
         <td>
           <input type="text" class="input_20_table" v-model="dns.tag" />
@@ -21,8 +21,8 @@
       </tr>
       <tr v-if="dns.hosts">
         <th>
-          {{ $t('components.Dns.label_hosts') }}
-          <hint v-html="$t('components.Dns.hint_hosts')"></hint>
+          {{ $t('com.Dns.label_hosts') }}
+          <hint v-html="$t('com.Dns.hint_hosts')"></hint>
         </th>
         <td>
           {{ Object.getOwnPropertyNames(dns.hosts).length }} item(s)
@@ -33,8 +33,8 @@
       </tr>
       <tr v-if="dns.servers">
         <th>
-          {{ $t('components.Dns.label_servers') }}
-          <hint v-html="$t('components.Dns.hint_servers')"></hint>
+          {{ $t('com.Dns.label_servers') }}
+          <hint v-html="$t('com.Dns.hint_servers')"></hint>
         </th>
         <td>
           {{ dns.servers.length }} item(s)
@@ -45,8 +45,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Dns.label_client_ip') }}
-          <hint v-html="$t('components.Dns.hint_client_ip')"></hint>
+          {{ $t('com.Dns.label_client_ip') }}
+          <hint v-html="$t('com.Dns.hint_client_ip')"></hint>
         </th>
         <td>
           <input type="text" maxlength="15" class="input_20_table" v-model="dns.clientIp" onkeypress="return validator.isIPAddr(this, event);" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -55,8 +55,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Dns.label_query_strategy') }}
-          <hint v-html="$t('components.Dns.hint_query_strategy')"></hint>
+          {{ $t('com.Dns.label_query_strategy') }}
+          <hint v-html="$t('com.Dns.hint_query_strategy')"></hint>
         </th>
         <td>
           <select class="input_option" v-model="dns.queryStrategy">
@@ -69,8 +69,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Dns.label_disable_cache') }}
-          <hint v-html="$t('components.Dns.hint_disable_cache')"></hint>
+          {{ $t('com.Dns.label_disable_cache') }}
+          <hint v-html="$t('com.Dns.hint_disable_cache')"></hint>
         </th>
         <td>
           <input type="checkbox" v-model="dns.disableCache" />
@@ -79,8 +79,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Dns.label_disable_fallback') }}
-          <hint v-html="$t('components.Dns.hint_disable_fallback')"></hint>
+          {{ $t('com.Dns.label_disable_fallback') }}
+          <hint v-html="$t('com.Dns.hint_disable_fallback')"></hint>
         </th>
         <td>
           <input type="checkbox" v-model="dns.disableFallback" />
@@ -89,8 +89,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Dns.label_fallback_if_match') }}
-          <hint v-html="$t('components.Dns.hint_fallback_if_match')"></hint>
+          {{ $t('com.Dns.label_fallback_if_match') }}
+          <hint v-html="$t('com.Dns.hint_fallback_if_match')"></hint>
         </th>
         <td>
           <input type="checkbox" v-model="dns.disableFallbackIfMatch" />

--- a/src/components/ImportConfig.vue
+++ b/src/components/ImportConfig.vue
@@ -1,6 +1,6 @@
 <template>
   <tr>
-    <th>{{ $t('components.ImportConfig.import_config_file') }}</th>
+    <th>{{ $t('com.ImportConfig.import_config_file') }}</th>
     <td>
       <span class="row-buttons">
         <a class="button_gen button_gen_small" href="#" @click.prevent="show">{{ $t('labels.import') }}</a>

--- a/src/components/Inbounds.vue
+++ b/src/components/Inbounds.vue
@@ -2,12 +2,12 @@
   <table width="100%" bordercolor="#6b8fa3" class="FormTable">
     <thead>
       <tr>
-        <td colspan="2">{{ $t('components.Inbounds.title') }}</td>
+        <td colspan="2">{{ $t('com.Inbounds.title') }}</td>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>{{ $t('components.Inbounds.label_create_new') }}</th>
+        <th>{{ $t('com.Inbounds.label_create_new') }}</th>
         <td>
           <select class="input_option" v-model="selectedInboundType" @change="edit_proxy()">
             <option></option>
@@ -49,7 +49,7 @@
     </tbody>
   </table>
 
-  <modal ref="inboundModal" :title="$t('components.Inbounds.modal_title_inbound_settings')">
+  <modal ref="inboundModal" :title="$t('com.Inbounds.modal_title_inbound_settings')">
     <component ref="inboundComponentRef" :is="inboundComponent" :inbound="selectedInbound" />
     <template v-slot:footer>
       <input class="button_gen button_gen_small" type="button" :value="$t('labels.save')" @click.prevent="save_inbound" />
@@ -158,7 +158,7 @@
         });
       };
       const remove_proxy = async (proxy: XrayInboundObject<IProtocolType>) => {
-        if (!window.confirm(t('components.Inbounds.alert_delete_confirm'))) return;
+        if (!window.confirm(t('com.Inbounds.alert_delete_confirm'))) return;
         let index = config.value.inbounds.indexOf(proxy);
         config.value.inbounds.splice(index, 1);
       };
@@ -166,7 +166,7 @@
       const save_inbound = async () => {
         let inbound = inboundComponentRef.value.inbound;
         if (config.value.inbounds.filter((i) => i != inbound && i.tag == inbound.tag).length > 0) {
-          alert(t('components.Inbounds.alert_tag_exists'));
+          alert(t('com.Inbounds.alert_tag_exists'));
           return;
         }
 

--- a/src/components/Outbounds.vue
+++ b/src/components/Outbounds.vue
@@ -2,12 +2,12 @@
   <table width="100%" bordercolor="#6b8fa3" class="FormTable">
     <thead>
       <tr>
-        <td colspan="2">{{ $t('components.Outbounds.title') }}</td>
+        <td colspan="2">{{ $t('com.Outbounds.title') }}</td>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>{{ $t('components.Outbounds.label_create_new') }}</th>
+        <th>{{ $t('com.Outbounds.label_create_new') }}</th>
         <td>
           <select class="input_option" v-model="selectedProxyType" @change="edit_proxy()">
             <option></option>
@@ -138,7 +138,7 @@
       };
 
       const remove_proxy = async (proxy: XrayOutboundObject<IProtocolType>) => {
-        if (!window.confirm(t('components.Outbounds.alert_delete_confirm'))) return;
+        if (!window.confirm(t('com.Outbounds.alert_delete_confirm'))) return;
         let index = config.value.outbounds.indexOf(proxy);
         config.value.outbounds.splice(index, 1);
       };
@@ -146,7 +146,7 @@
       const save_proxy = async () => {
         let proxy = proxyRef.value.proxy;
         if (config.value.outbounds.filter((i) => i != proxy && i.tag == proxy.tag).length > 0) {
-          alert(t('components.Outbounds.alert_tag_exists'));
+          alert(t('com.Outbounds.alert_tag_exists'));
           return;
         }
 

--- a/src/components/ProcessUptime.vue
+++ b/src/components/ProcessUptime.vue
@@ -1,6 +1,6 @@
 <template>
   <tr v-if="isRunning">
-    <th>{{ $t('components.ProcessUptime.label') }}</th>
+    <th>{{ $t('com.ProcessUptime.label') }}</th>
     <td>{{ formattedTime }}</td>
   </tr>
 </template>
@@ -51,7 +51,7 @@
         totalSeconds -= hours * 3600;
         const minutes = Math.floor(totalSeconds / 60);
         totalSeconds -= minutes * 60;
-        return t('components.ProcessUptime.formatted_time', [days, hours, minutes, totalSeconds]);
+        return t('com.ProcessUptime.formatted_time', [days, hours, minutes, totalSeconds]);
       });
 
       return {

--- a/src/components/Profiles.vue
+++ b/src/components/Profiles.vue
@@ -1,15 +1,15 @@
 <template>
   <tr v-if="profile">
     <th>
-      {{ $t('components.Profiles.manager') }}
-      <hint v-html="$t('components.Profiles.hint')"></hint>
+      {{ $t('com.Profiles.manager') }}
+      <hint v-html="$t('com.Profiles.hint')"></hint>
     </th>
     <td>
       <select v-model="profile" class="input_option" @change="change_profile()">
         <option v-for="p in profiles" :value="p" :key="p">{{ p.replace('.json', '') }}</option>
       </select>
       <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click.prevent="manage()" />
-      <modal ref="modal" :title="$t('components.Profiles.modal_title')" width="400">
+      <modal ref="modal" :title="$t('com.Profiles.modal_title')" width="400">
         <table class="FormTable modal-form-table">
           <tbody>
             <tr v-for="p in profiles" :key="p">

--- a/src/components/ReverseProxy.vue
+++ b/src/components/ReverseProxy.vue
@@ -3,16 +3,16 @@
     <thead>
       <tr>
         <td colspan="2">
-          {{ $t('components.ReverseProxy.title') }}
-          <hint v-html="$t('components.ReverseProxy.hint_title')"></hint>
+          {{ $t('com.ReverseProxy.title') }}
+          <hint v-html="$t('com.ReverseProxy.hint_title')"></hint>
         </td>
       </tr>
     </thead>
     <tbody>
       <tr v-if="reverse.bridges">
         <th>
-          {{ $t('components.ReverseProxy.label_bridges') }}
-          <hint v-html="$t('components.ReverseProxy.hint_bridges')"></hint>
+          {{ $t('com.ReverseProxy.label_bridges') }}
+          <hint v-html="$t('com.ReverseProxy.hint_bridges')"></hint>
         </th>
         <td>
           {{ reverse.bridges.length }} item(s)
@@ -22,8 +22,8 @@
       </tr>
       <tr v-if="reverse.portals">
         <th>
-          {{ $t('components.ReverseProxy.label_portals') }}
-          <hint v-html="$t('components.ReverseProxy.hint_portals')"></hint>
+          {{ $t('com.ReverseProxy.label_portals') }}
+          <hint v-html="$t('com.ReverseProxy.hint_portals')"></hint>
         </th>
         <td>
           {{ reverse.portals.length }} item(s)

--- a/src/components/Routing.vue
+++ b/src/components/Routing.vue
@@ -3,16 +3,16 @@
     <thead>
       <tr>
         <td colspan="2">
-          {{ $t('components.Routing.title') }}
-          <hint v-html="$t('components.Routing.hint_title')"></hint>
+          {{ $t('com.Routing.title') }}
+          <hint v-html="$t('com.Routing.hint_title')"></hint>
         </td>
       </tr>
     </thead>
     <tbody>
       <tr>
         <th>
-          {{ $t('components.Routing.label_domain_strategy') }}
-          <hint v-html="$t('components.Routing.hint_domain_strategy')"></hint>
+          {{ $t('com.Routing.label_domain_strategy') }}
+          <hint v-html="$t('com.Routing.hint_domain_strategy')"></hint>
         </th>
         <td>
           <select class="input_option" v-model="routing.domainStrategy">
@@ -25,8 +25,8 @@
       </tr>
       <tr>
         <th>
-          {{ $t('components.Routing.label_domain_matcher') }}
-          <hint v-html="$t('components.Routing.hint_domain_matcher')"></hint>
+          {{ $t('com.Routing.label_domain_matcher') }}
+          <hint v-html="$t('com.Routing.hint_domain_matcher')"></hint>
         </th>
         <td>
           <select class="input_option" v-model="routing.domainMatcher">
@@ -39,8 +39,8 @@
       </tr>
       <tr v-if="routing.policies">
         <th>
-          {{ $t('components.Routing.label_policies') }}
-          <hint v-html="$t('components.Routing.hint_policies')"></hint>
+          {{ $t('com.Routing.label_policies') }}
+          <hint v-html="$t('com.Routing.hint_policies')"></hint>
         </th>
         <td>
           {{ routing.policies.length }} item(s)
@@ -50,8 +50,8 @@
       </tr>
       <tr v-if="routing.rules">
         <th>
-          {{ $t('components.Routing.label_rules') }}
-          <hint v-html="$t('components.Routing.hint_rules')"></hint>
+          {{ $t('com.Routing.label_rules') }}
+          <hint v-html="$t('com.Routing.hint_rules')"></hint>
         </th>
         <td>
           {{ countRules() }} item(s)
@@ -61,13 +61,13 @@
       </tr>
       <tr v-if="routing.rules">
         <th>
-          {{ $t('components.Routing.label_geodat_metadata') }}
-          <hint v-html="$t('components.Routing.hint_geodat_metadata')"></hint>
+          {{ $t('com.Routing.label_geodat_metadata') }}
+          <hint v-html="$t('com.Routing.hint_geodat_metadata')"></hint>
         </th>
         <td>
-          <input class="button_gen button_gen_small" type="button" :value="$t('components.Routing.manage_local_files')" @click.prevent="manage_geodat()" />
+          <input class="button_gen button_gen_small" type="button" :value="$t('com.Routing.manage_local_files')" @click.prevent="manage_geodat()" />
           <geodat-modal ref="geodatModal"></geodat-modal>
-          <input class="button_gen button_gen_small" type="button" :value="$t('components.Routing.update_community_files')" @click.prevent="update_geodat()" />
+          <input class="button_gen button_gen_small" type="button" :value="$t('com.Routing.update_community_files')" @click.prevent="update_geodat()" />
           <span class="hint-small" v-if="daysPassed > 1"> updated {{ daysPassed }} days ago</span>
           <span class="hint-color"> [<a href="https://github.com/Loyalsoldier/v2ray-rules-dat/releases" target="_blank">source</a>, <a href="https://github.com/v2fly/domain-list-community/tree/master/data" target="_blank">geosite</a>] </span>
         </td>

--- a/src/components/ServiceStatus.vue
+++ b/src/components/ServiceStatus.vue
@@ -3,14 +3,14 @@
     <thead>
       <tr>
         <td colspan="2">
-          {{ $t('components.ClientStatus.configuration') }}
+          {{ $t('com.ClientStatus.configuration') }}
           <xray-version></xray-version>
         </td>
       </tr>
     </thead>
     <tbody>
       <tr>
-        <th>{{ $t('components.ClientStatus.connection_status') }}</th>
+        <th>{{ $t('com.ClientStatus.connection_status') }}</th>
         <td>
           <span class="label" :class="connectionClasses" v-text="statusLabel"></span>
           <span v-if="!isRunning">
@@ -30,7 +30,7 @@
       <process-uptime></process-uptime>
       <import-config v-model:config="config"></import-config>
       <tr>
-        <th>{{ $t('components.ClientStatus.general_options') }}</th>
+        <th>{{ $t('com.ClientStatus.general_options') }}</th>
         <td>
           <span class="row-buttons">
             <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click.prevent="manage_general_options()" />
@@ -82,7 +82,7 @@
     },
     computed: {
       statusLabel(): string {
-        return !this.checkConEnabled ? (this.isRunning ? this.$t('components.ClientStatus.xray_running') : this.$t('components.ClientStatus.xray_stopped')) : this.connectionStationLabel;
+        return !this.checkConEnabled ? (this.isRunning ? this.$t('com.ClientStatus.xray_running') : this.$t('com.ClientStatus.xray_stopped')) : this.connectionStationLabel;
       }
     },
     setup(props) {
@@ -92,7 +92,7 @@
       const generalOptionsModal = ref();
       const contryCodeClass = ref<string>('flag-icon flag-icon-unknown');
       const connectionStatus = ref<boolean>(false);
-      const connectionStationLabel = ref<string>(t('components.ClientStatus.xray_running'));
+      const connectionStationLabel = ref<string>(t('com.ClientStatus.xray_running'));
       const connectionClasses = computed(() => ({
         'label-success': isRunning.value,
         'label-error': !isRunning.value,
@@ -123,7 +123,7 @@
             status.connected = config.value.outbounds?.find((o) => o.protocol !== XrayProtocol.BLACKHOLE && o.protocol !== XrayProtocol.FREEDOM && o.settings?.isTargetAddress?.(status.query!)) !== undefined;
             isRunning.value = window.xray.server.isRunning;
             connectionStatus.value = status.connected;
-            connectionStationLabel.value = status.connected ? t('components.ClientStatus.xray_connected') : t('components.ClientStatus.xray_connecting');
+            connectionStationLabel.value = status.connected ? t('com.ClientStatus.xray_connected') : t('com.ClientStatus.xray_connecting');
             contryCodeClass.value = `fi-${status.countryCode?.toLowerCase()}`;
             return status;
           }

--- a/src/components/Version.vue
+++ b/src/components/Version.vue
@@ -1,26 +1,26 @@
 <template>
   <div class="version">
     <a href="#" @click.prevent="open_update">
-      <span class="button_gen button_gen_small button_info" :title="$t('components.Version.tooltip_update_avialable')" v-if="hasUpdate">!</span>
+      <span class="button_gen button_gen_small button_info" :title="$t('com.Version.tooltip_update_avialable')" v-if="hasUpdate">!</span>
       XRAYUI v{{ current_version }}</a
     >
   </div>
-  <modal ref="updateModal" width="600" :title="$t('components.Version.modal_title')">
+  <modal ref="updateModal" width="600" :title="$t('com.Version.modal_title')">
     <div class="modal-content">
-      <p class="current-version">{{ $t('components.Version.current_version', [current_version]) }}</p>
+      <p class="current-version">{{ $t('com.Version.current_version', [current_version]) }}</p>
       <div v-if="hasUpdate" class="update-details">
-        <p v-html="$t('components.Version.new_version', [latest_version])"></p>
+        <p v-html="$t('com.Version.new_version', [latest_version])"></p>
       </div>
-      <p v-else class="no-updates">{{ $t('components.Version.version_is_up_to_date') }}</p>
+      <p v-else class="no-updates">{{ $t('com.Version.version_is_up_to_date') }}</p>
 
       <div class="textarea-wrapper">
         <div class="changelog" v-html="changelog"></div>
-        <p v-html="$t('components.Version.open_chengelog')"></p>
+        <p v-html="$t('com.Version.open_chengelog')"></p>
       </div>
     </div>
     <template v-slot:footer v-if="hasUpdate">
-      <button class="button_gen button_gen_small" @click.prevent="dont_want_update">{{ $t('components.Version.dont_want_update', [latest_version]) }}</button>
-      <input class="button_gen button_gen_small button-primary" type="button" :value="$t('components.Version.update_now')" @click.prevent="update" />
+      <button class="button_gen button_gen_small" @click.prevent="dont_want_update">{{ $t('com.Version.dont_want_update', [latest_version]) }}</button>
+      <input class="button_gen button_gen_small button-primary" type="button" :value="$t('com.Version.update_now')" @click.prevent="update" />
     </template>
   </modal>
 </template>

--- a/src/components/inbounds/DocodemoDoorInbound.vue
+++ b/src/components/inbounds/DocodemoDoorInbound.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="formfontdesc">
-    <p>{{ $t('components.DocodemoDoorInbound.modal_desc') }}</p>
+    <p>{{ $t('com.DocodemoDoorInbound.modal_desc') }}</p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.DocodemoDoorInbound.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.DocodemoDoorInbound.modal_title') }}</td>
         </tr>
       </thead>
       <tbody>
         <inbound-common :inbound="inbound"></inbound-common>
         <tr>
           <th>
-            {{ $t('components.DocodemoDoorInbound.label_follow_redirect') }}
-            <hint v-html="$t('components.DocodemoDoorInbound.hint_follow_redirect')"></hint>
+            {{ $t('com.DocodemoDoorInbound.label_follow_redirect') }}
+            <hint v-html="$t('com.DocodemoDoorInbound.hint_follow_redirect')"></hint>
           </th>
           <td>
             <input type="checkbox" v-model="inbound.settings.followRedirect" />
@@ -21,8 +21,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.DocodemoDoorInbound.label_address') }}
-            <hint v-html="$t('components.DocodemoDoorInbound.hint_address')"></hint>
+            {{ $t('com.DocodemoDoorInbound.label_address') }}
+            <hint v-html="$t('com.DocodemoDoorInbound.hint_address')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="inbound.settings.address" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -31,8 +31,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.DocodemoDoorInbound.label_port') }}
-            <hint v-html="$t('components.DocodemoDoorInbound.hint_port')"></hint>
+            {{ $t('com.DocodemoDoorInbound.label_port') }}
+            <hint v-html="$t('com.DocodemoDoorInbound.hint_port')"></hint>
           </th>
           <td>
             <input type="number" maxlength="5" class="input_6_table" v-model="inbound.settings.port" autocorrect="off" autocapitalize="off" onkeypress="return validator.isNumber(this,event);" />
@@ -41,8 +41,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.DocodemoDoorInbound.label_network') }}
-            <hint v-html="$t('components.DocodemoDoorInbound.hint_network')"></hint>
+            {{ $t('com.DocodemoDoorInbound.label_network') }}
+            <hint v-html="$t('com.DocodemoDoorInbound.hint_network')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="inbound.settings.network">

--- a/src/components/inbounds/InboundCommon.vue
+++ b/src/components/inbounds/InboundCommon.vue
@@ -1,8 +1,8 @@
 <template>
   <tr>
     <th>
-      {{ $t('components.InboundCommon.label_tag') }}
-      <hint v-html="$t('components.InboundCommon.hint_tag')"></hint>
+      {{ $t('com.InboundCommon.label_tag') }}
+      <hint v-html="$t('com.InboundCommon.hint_tag')"></hint>
     </th>
     <td>
       <input type="text" class="input_20_table" v-model="inbound.tag" />
@@ -11,8 +11,8 @@
   </tr>
   <tr>
     <th>
-      {{ $t('components.InboundCommon.label_listen') }}
-      <hint v-html="$t('components.InboundCommon.hint_listen')"></hint>
+      {{ $t('com.InboundCommon.label_listen') }}
+      <hint v-html="$t('com.InboundCommon.hint_listen')"></hint>
     </th>
     <td>
       <input type="text" maxlength="15" class="input_20_table" v-model="inbound.listen" onkeypress="return validator.isIPAddr(this, event);" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -21,13 +21,13 @@
   </tr>
   <tr>
     <th>
-      {{ $t('components.InboundCommon.label_port') }}
-      <hint v-html="$t('components.InboundCommon.hint_port')"></hint>
+      {{ $t('com.InboundCommon.label_port') }}
+      <hint v-html="$t('com.InboundCommon.hint_port')"></hint>
     </th>
     <td>
       <input type="number" id="po1" maxlength="5" class="input_6_table" v-model="inbound.port" autocorrect="off" autocapitalize="off" onkeypress="return validator.isNumber(this,event);" />
       <span class="row-buttons">
-        <a class="button_gen button_gen_small" href="#" @click="show_allocate(inbound)">{{ $t('components.InboundCommon.label_port_allocate') }}</a>
+        <a class="button_gen button_gen_small" href="#" @click="show_allocate(inbound)">{{ $t('com.InboundCommon.label_port_allocate') }}</a>
       </span>
       <allocate-modal ref="allocateModal" />
     </td>

--- a/src/components/modals/AllocateModal.vue
+++ b/src/components/modals/AllocateModal.vue
@@ -1,17 +1,17 @@
 <template>
-  <modal ref="modal" :title="$t('components.AllocateModal.modal_title')" width="500">
+  <modal ref="modal" :title="$t('com.AllocateModal.modal_title')" width="500">
     <div class="formfontdesc">
       <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.AllocateModal.label_settings') }}</td>
+            <td colspan="2">{{ $t('com.AllocateModal.label_settings') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>
-              {{ $t('components.AllocateModal.label_strategy') }}
-              <hint v-html="$t('components.AllocateModal.hint_strategy')"></hint>
+              {{ $t('com.AllocateModal.label_strategy') }}
+              <hint v-html="$t('com.AllocateModal.hint_strategy')"></hint>
             </th>
             <td>
               <select v-model="allocate.strategy" class="input_option">
@@ -22,8 +22,8 @@
           </tr>
           <tr v-if="allocate.strategy == 'random'">
             <th>
-              {{ $t('components.AllocateModal.label_refresh') }}
-              <hint v-html="$t('components.AllocateModal.hint_refresh')"></hint>
+              {{ $t('com.AllocateModal.label_refresh') }}
+              <hint v-html="$t('com.AllocateModal.hint_refresh')"></hint>
             </th>
             <td>
               <input type="text" maxlength="2" class="input_6_table" v-model="allocate.refresh" onkeypress="return validator.isNumber(this,event);" />
@@ -32,8 +32,8 @@
           </tr>
           <tr v-if="allocate.strategy == 'random'">
             <th>
-              {{ $t('components.AllocateModal.label_concurrency') }}
-              <hint v-html="$t('components.AllocateModal.hint_concurrency')"></hint>
+              {{ $t('com.AllocateModal.label_concurrency') }}
+              <hint v-html="$t('com.AllocateModal.hint_concurrency')"></hint>
             </th>
             <td>
               <input type="text" maxlength="2" class="input_6_table" v-model="allocate.concurrency" onkeypress="return validator.isNumber(this,event);" />

--- a/src/components/modals/CertificatesModal.vue
+++ b/src/components/modals/CertificatesModal.vue
@@ -1,11 +1,11 @@
 <template>
-  <modal width="755" ref="certModal" :title="$t('components.CertificatesModal.modal_title')">
+  <modal width="755" ref="certModal" :title="$t('com.CertificatesModal.modal_title')">
     <table class="FormTable modal-form-table">
       <tbody>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_ocsp_stapling') }}
-            <hint v-html="$t('components.CertificatesModal.hint_ocsp_stapling')"></hint>
+            {{ $t('com.CertificatesModal.label_ocsp_stapling') }}
+            <hint v-html="$t('com.CertificatesModal.hint_ocsp_stapling')"></hint>
           </th>
           <td>
             <input v-model="certificate.ocspStapling" type="number" maxlength="4" class="input_6_table" onkeypress="return validator.isNumber(this,event);" />
@@ -14,8 +14,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_one_time_loading') }}
-            <hint v-html="$t('components.CertificatesModal.hint_one_time_loading')"></hint>
+            {{ $t('com.CertificatesModal.label_one_time_loading') }}
+            <hint v-html="$t('com.CertificatesModal.hint_one_time_loading')"></hint>
           </th>
           <td>
             <input v-model="certificate.oneTimeLoading" type="checkbox" class="input" />
@@ -23,8 +23,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_usage') }}
-            <hint v-html="$t('components.CertificatesModal.hint_usage')"></hint>
+            {{ $t('com.CertificatesModal.label_usage') }}
+            <hint v-html="$t('com.CertificatesModal.hint_usage')"></hint>
           </th>
           <td>
             <template v-for="(opt, index) in usageOptions" :key="index">
@@ -36,8 +36,8 @@
         </tr>
         <tr v-if="certificate.usage == 'issue'">
           <th>
-            {{ $t('components.CertificatesModal.label_build_chain') }}
-            <hint v-html="$t('components.CertificatesModal.hint_build_chain')"></hint>
+            {{ $t('com.CertificatesModal.label_build_chain') }}
+            <hint v-html="$t('com.CertificatesModal.hint_build_chain')"></hint>
           </th>
           <td>
             <input v-model="certificate.buildChain" type="checkbox" class="input" />
@@ -45,8 +45,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_certificate_file') }}
-            <hint v-html="$t('components.CertificatesModal.hint_certificate_file')"></hint>
+            {{ $t('com.CertificatesModal.label_certificate_file') }}
+            <hint v-html="$t('com.CertificatesModal.hint_certificate_file')"></hint>
           </th>
           <td>
             <input v-model="certificate.certificateFile" type="text" class="input_25_table" :disabled="(certificate.certificate?.length ?? 0) > 0" />
@@ -54,8 +54,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_certificate_content') }}
-            <hint v-html="$t('components.CertificatesModal.hint_certificate_content')"></hint>
+            {{ $t('com.CertificatesModal.label_certificate_content') }}
+            <hint v-html="$t('com.CertificatesModal.hint_certificate_content')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">
@@ -65,8 +65,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_key_file') }}
-            <hint v-html="$t('components.CertificatesModal.hint_key_file')"></hint>
+            {{ $t('com.CertificatesModal.label_key_file') }}
+            <hint v-html="$t('com.CertificatesModal.hint_key_file')"></hint>
           </th>
           <td>
             <input v-model="certificate.keyFile" type="text" class="input_25_table" :disabled="(certificate.key?.length ?? 0) > 0" />
@@ -74,8 +74,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.CertificatesModal.label_key_content') }}
-            <hint v-html="$t('components.CertificatesModal.hint_key_content')"></hint>
+            {{ $t('com.CertificatesModal.label_key_content') }}
+            <hint v-html="$t('com.CertificatesModal.hint_key_content')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">

--- a/src/components/modals/ConfigModal.vue
+++ b/src/components/modals/ConfigModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <modal ref="modal" :title="$t('components.ConfigModal.modal_title')" width="800">
+  <modal ref="modal" :title="$t('com.ConfigModal.modal_title')" width="800">
     <div class="formfontdesc">
       <div class="configArea">
         <json-pretty :data="configJson" :deep="2" :show-line-number="true" :show-icon="true" :show-line="false" :show-length="true"> </json-pretty>
@@ -9,11 +9,11 @@
     <template v-slot:footer>
       <label>
         <input type="checkbox" v-model="hideSenseData" @change="hide_sense_data" />
-        {{ $t('components.ConfigModal.hide_sensetive_data') }}
+        {{ $t('com.ConfigModal.hide_sensetive_data') }}
       </label>
-      <input class="button_gen button_gen_small" type="button" :value="$t('components.ConfigModal.copy_to_clipboard')" @click.prevent="copy_to_clipboard" />
+      <input class="button_gen button_gen_small" type="button" :value="$t('com.ConfigModal.copy_to_clipboard')" @click.prevent="copy_to_clipboard" />
       <a class="button_gen button_gen_small" :href="configUri" target="_blank">
-        {{ $t('components.ConfigModal.open_raw') }}
+        {{ $t('com.ConfigModal.open_raw') }}
       </a>
     </template>
   </modal>
@@ -105,9 +105,9 @@
           try {
             await navigator.clipboard.writeText(configStr);
             if (hideSenseData.value) {
-              alert(t('components.ConfigModal.alert_copy_ok_hiddendata'));
+              alert(t('com.ConfigModal.alert_copy_ok_hiddendata'));
             } else {
-              alert(t('components.ConfigModal.alert_copy_ok_nohiddendata'));
+              alert(t('com.ConfigModal.alert_copy_ok_nohiddendata'));
             }
           } catch (err) {
             console.error('Clipboard API error, falling back', err);
@@ -142,9 +142,9 @@
             alert('Copying to clipboard failed. Please copy the text manually:\n\n' + text);
           } else {
             if (hideSenseData.value) {
-              alert(t('components.ConfigModal.alert_copy_ok_hiddendata'));
+              alert(t('com.ConfigModal.alert_copy_ok_hiddendata'));
             } else {
-              alert(t('components.ConfigModal.alert_copy_ok_nohiddendata'));
+              alert(t('com.ConfigModal.alert_copy_ok_nohiddendata'));
             }
           }
         } catch (err) {

--- a/src/components/modals/DnsServersModal.vue
+++ b/src/components/modals/DnsServersModal.vue
@@ -1,16 +1,16 @@
 <template>
   <modal ref="modal" title="Servers">
     <div class="formfontdesc">
-      <p>{{ $t('components.DnsServersModal.modal_desc') }}</p>
+      <p>{{ $t('com.DnsServersModal.modal_desc') }}</p>
       <table width="100%" bordercolor="#6b8fa3" class="FormTable SettingsTable tableApi_table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.DnsServersModal.list') }}</td>
+            <td colspan="2">{{ $t('com.DnsServersModal.list') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr class="row_title">
-            <th>{{ $t('components.DnsServersModal.server') }}</th>
+            <th>{{ $t('com.DnsServersModal.server') }}</th>
             <th></th>
           </tr>
           <tr class="row_title">
@@ -18,12 +18,12 @@
               <input v-model="server.address" class="input_25_table" placeholder="address" />
             </td>
             <td>
-              <button @click.prevent="advanced()" class="button_gen button_gen_small">{{ $t('components.DnsServersModal.advanced') }}</button>
+              <button @click.prevent="advanced()" class="button_gen button_gen_small">{{ $t('com.DnsServersModal.advanced') }}</button>
               <button @click.prevent="addSimple()" class="button_gen button_gen_small">{{ $t('labels.add') }}</button>
             </td>
           </tr>
           <tr v-if="!servers.length" class="data_tr">
-            <td colspan="2" style="color: #ffcc00">{{ $t('components.DnsServersModal.no_hosts_defined') }}</td>
+            <td colspan="2" style="color: #ffcc00">{{ $t('com.DnsServersModal.no_hosts_defined') }}</td>
           </tr>
           <tr v-for="(server, index) in servers" :key="index" class="data_tr">
             <td>{{ getServer(server) }}</td>
@@ -39,18 +39,18 @@
   </modal>
 
   <!-- Advanced Modal -->
-  <modal ref="modalAdvanced" :title="$t('components.DnsServersModal.modal_server_title')" width="500px">
+  <modal ref="modalAdvanced" :title="$t('com.DnsServersModal.modal_server_title')" width="500px">
     <div class="formfontdesc">
       <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.DnsServersModal.modal_server_title2') }}</td>
+            <td colspan="2">{{ $t('com.DnsServersModal.modal_server_title2') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_address') }}
+              {{ $t('com.DnsServersModal.label_address') }}
             </th>
             <td>
               <input type="text" v-model="server.address" class="input_25_table" placeholder="address" />
@@ -58,8 +58,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_client_ip') }}
-              <hint v-html="$t('components.DnsServersModal.hint_client_ip')"></hint>
+              {{ $t('com.DnsServersModal.label_client_ip') }}
+              <hint v-html="$t('com.DnsServersModal.hint_client_ip')"></hint>
             </th>
             <td>
               <input type="text" v-model="server.clientIP" class="input_25_table" placeholder="client ip" />
@@ -67,8 +67,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_port') }}
-              <hint v-html="$t('components.DnsServersModal.hint_port')"></hint>
+              {{ $t('com.DnsServersModal.label_port') }}
+              <hint v-html="$t('com.DnsServersModal.hint_port')"></hint>
             </th>
             <td>
               <input type="number" v-model="server.port" class="input_6_table" placeholder="port" />
@@ -77,8 +77,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_domains') }}
-              <hint v-html="$t('components.DnsServersModal.hint_domains')"></hint>
+              {{ $t('com.DnsServersModal.label_domains') }}
+              <hint v-html="$t('com.DnsServersModal.hint_domains')"></hint>
             </th>
             <td>
               <div class="textarea-wrapper">
@@ -88,8 +88,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_expected_ips') }}
-              <hint v-html="$t('components.DnsServersModal.hint_expected_ips')"></hint>
+              {{ $t('com.DnsServersModal.label_expected_ips') }}
+              <hint v-html="$t('com.DnsServersModal.hint_expected_ips')"></hint>
             </th>
             <td>
               <div class="textarea-wrapper">
@@ -99,8 +99,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.DnsServersModal.label_skip_fallback') }}
-              <hint v-html="$t('components.DnsServersModal.hint_skip_fallback')"></hint>
+              {{ $t('com.DnsServersModal.label_skip_fallback') }}
+              <hint v-html="$t('com.DnsServersModal.hint_skip_fallback')"></hint>
             </th>
             <td>
               <input type="checkbox" v-model="server.skipFallback" />

--- a/src/components/modals/GeneralOptionsModal.vue
+++ b/src/components/modals/GeneralOptionsModal.vue
@@ -1,10 +1,10 @@
 <template>
-  <modal ref="modal" :title="$t('components.GeneralOptionsModal.modal_title')" width="700">
+  <modal ref="modal" :title="$t('com.GeneralOptionsModal.modal_title')" width="700">
     <div class="formfontdesc">
       <table class="FormTable modal-form-table">
         <tbody>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.start_xray_on_reboot') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.start_xray_on_reboot') }}</th>
             <td>
               <label class="go-option">
                 <input type="checkbox" v-model="options.startup" @click="updatestartup" />
@@ -12,13 +12,13 @@
             </td>
           </tr>
           <tr v-show="validateCheckConOption()">
-            <th>{{ $t('components.GeneralOptionsModal.check_xray_connection') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.check_xray_connection') }}</th>
             <td>
               <label class="go-option">
                 <input type="checkbox" v-model="checkconenabled" @change="setcheckconnection" />
               </label>
-              <modal ref="conModal" :title="$t('components.GeneralOptionsModal.modalConnectTitle')" width="450">
-                <div class="formfontdesc" v-html="$t('components.GeneralOptionsModal.modalConnectCheckDescription')"></div>
+              <modal ref="conModal" :title="$t('com.GeneralOptionsModal.modalConnectTitle')" width="450">
+                <div class="formfontdesc" v-html="$t('com.GeneralOptionsModal.modalConnectCheckDescription')"></div>
                 <template #footer>
                   <input class="button_gen button_gen_small" type="button" :value="$t('labels.cancel')" @click.prevent="concheckcancel" />
                   <input class="button_gen button_gen_small" type="button" :value="$t('labels.accept')" @click.prevent="concheckaccept" />
@@ -28,8 +28,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.GeneralOptionsModal.label_gh_proxy') }}
-              <hint v-html="$t('components.GeneralOptionsModal.hint_gh_proxy')"></hint>
+              {{ $t('com.GeneralOptionsModal.label_gh_proxy') }}
+              <hint v-html="$t('com.GeneralOptionsModal.hint_gh_proxy')"></hint>
             </th>
             <td>
               <select class="input_option" v-model="options.github_proxy">
@@ -43,12 +43,12 @@
       <table class="FormTable modal-form-table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.GeneralOptionsModal.geodad_header') }}</td>
+            <td colspan="2">{{ $t('com.GeneralOptionsModal.geodad_header') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.wellknown_geodata') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.wellknown_geodata') }}</th>
             <td>
               <select class="input_option" v-model="selected_wellknown" @change="setwellknown">
                 <option></option>
@@ -60,13 +60,13 @@
             </td>
           </tr>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.label_geoip_url') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_geoip_url') }}</th>
             <td>
               <input v-model="options.geo_ip_url" type="text" class="input_32_table" />
             </td>
           </tr>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.label_geosite_url') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_geosite_url') }}</th>
             <td>
               <input v-model="options.geo_site_url" type="text" class="input_32_table" />
             </td>
@@ -76,12 +76,12 @@
       <table class="FormTable modal-form-table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.GeneralOptionsModal.logs_header') }}</td>
+            <td colspan="2">{{ $t('com.GeneralOptionsModal.logs_header') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.label_logs_enable_access') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_logs_enable_access') }}</th>
             <td>
               <label class="go-option">
                 <input type="checkbox" v-model="options.logs_access" />
@@ -90,7 +90,7 @@
             </td>
           </tr>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.label_logs_enable_error') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_logs_enable_error') }}</th>
             <td>
               <label class="go-option">
                 <input type="checkbox" v-model="options.logs_error" />
@@ -99,7 +99,7 @@
             </td>
           </tr>
           <tr v-if="options.logs_error">
-            <th>{{ $t('components.GeneralOptionsModal.label_logs_level') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_logs_level') }}</th>
             <td>
               <select class="input_option" v-model="options.logs_level">
                 <option v-for="level in log_levels" :value="level">{{ level }}</option>
@@ -108,7 +108,7 @@
             </td>
           </tr>
           <tr>
-            <th>{{ $t('components.GeneralOptionsModal.label_logs_enable_dns') }}</th>
+            <th>{{ $t('com.GeneralOptionsModal.label_logs_enable_dns') }}</th>
             <td>
               <label class="go-option">
                 <input type="checkbox" v-model="options.logs_dns" />

--- a/src/components/modals/GeodatModal.vue
+++ b/src/components/modals/GeodatModal.vue
@@ -1,16 +1,16 @@
 <template>
-  <modal ref="modal" :title="$t('components.GeodatModal.modal_title')" width="700">
+  <modal ref="modal" :title="$t('com.GeodatModal.modal_title')" width="700">
     <div class="formfontdesc">
       <div style="text-align: left">
         <p>
-          {{ $t('components.GeodatModal.modal_desc') }}
+          {{ $t('com.GeodatModal.modal_desc') }}
         </p>
       </div>
       <table class="FormTable modal-form-table">
         <tbody v-if="isLoading">
           <tr>
             <th>
-              {{ $t('components.GeodatModal.loading') }}
+              {{ $t('com.GeodatModal.loading') }}
             </th>
             <td>
               <div class="loading"></div>
@@ -20,11 +20,11 @@
         <tbody v-if="geodata && !isLoading">
           <tr>
             <th>
-              {{ $t('components.GeodatModal.label_select_file') }}
+              {{ $t('com.GeodatModal.label_select_file') }}
             </th>
             <td>
               <select v-model="file.tag" class="input_option" @change="loadContent">
-                <option value>{{ $t('components.GeodatModal.option_create_new_file') }}</option>
+                <option value>{{ $t('com.GeodatModal.option_create_new_file') }}</option>
                 <option v-for="opt in geodata.tags" :key="opt" :value="opt">
                   {{ opt }}
                 </option>
@@ -36,8 +36,8 @@
         <tbody v-if="geodata && isSelected && !isLoading">
           <tr v-if="isNewFile">
             <th>
-              {{ $t('components.GeodatModal.label_tag') }}
-              <hint v-html="$t('components.GeodatModal.hint_tag')"></hint>
+              {{ $t('com.GeodatModal.label_tag') }}
+              <hint v-html="$t('com.GeodatModal.hint_tag')"></hint>
             </th>
             <td>
               <input v-model="file.tag" class="input_25_table" placeholder="tag" />
@@ -45,8 +45,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.GeodatModal.label_content') }}
-              <hint v-html="$t('components.GeodatModal.hint_content')"></hint>
+              {{ $t('com.GeodatModal.label_content') }}
+              <hint v-html="$t('com.GeodatModal.hint_content')"></hint>
             </th>
             <td>
               <div class="textarea-wrapper">
@@ -60,8 +60,8 @@
     <template v-slot:footer>
       <div>
         <input class="button_gen button_gen_small" type="button" :value="$t('labels.delete')" @click.prevent="deletdat" v-show="!isNewFile && isSelected" />
-        <input class="button_gen button_gen_small" type="button" :value="$t('components.GeodatModal.recompile_all')" :title="$t('components.GeodatModal.hit_recompile_all')" @click.prevent="complile_all" v-if="!isSelected" />
-        <input class="button_gen button_gen_small" type="button" :value="$t('components.GeodatModal.compile')" v-show="isSelected" :title="$t('components.GeodatModal.hit_compile')" @click.prevent="compile" />
+        <input class="button_gen button_gen_small" type="button" :value="$t('com.GeodatModal.recompile_all')" :title="$t('com.GeodatModal.hit_recompile_all')" @click.prevent="complile_all" v-if="!isSelected" />
+        <input class="button_gen button_gen_small" type="button" :value="$t('com.GeodatModal.compile')" v-show="isSelected" :title="$t('com.GeodatModal.hit_compile')" @click.prevent="compile" />
       </div>
     </template>
   </modal>
@@ -126,7 +126,7 @@
       const compile = async () => {
         await engine.executeWithLoadingProgress(async () => {
           if (!file.value.content?.length) {
-            alert(t('components.GeodatModal.alert_empty_content'));
+            alert(t('com.GeodatModal.alert_empty_content'));
             return;
           }
 
@@ -135,7 +135,7 @@
       };
 
       const deletdat = async () => {
-        if (!confirm(t('components.GeodatModal.alert_delete_confirm'))) return;
+        if (!confirm(t('com.GeodatModal.alert_delete_confirm'))) return;
 
         await engine.executeWithLoadingProgress(async () => {
           await engine.submit(SubmtActions.geoDataCustomDeleteTag, { tag: file.value.tag });

--- a/src/components/modals/ImportConfigModal.vue
+++ b/src/components/modals/ImportConfigModal.vue
@@ -1,13 +1,13 @@
 <template>
-  <modal ref="importModal" :title="$t('components.ImportConfigModal.modal_title')" width="700">
+  <modal ref="importModal" :title="$t('com.ImportConfigModal.modal_title')" width="700">
     <div class="formfontdesc">
-      <p v-html="$t('components.ImportConfigModal.modal_desc')"></p>
+      <p v-html="$t('com.ImportConfigModal.modal_desc')"></p>
       <table class="FormTable modal-form-table">
         <tbody>
           <tr>
             <th>
-              {{ $t('components.ImportConfigModal.label_qr_code') }}
-              <hint v-html="$t('components.ImportConfigModal.hint_qr_code')"></hint>
+              {{ $t('com.ImportConfigModal.label_qr_code') }}
+              <hint v-html="$t('com.ImportConfigModal.hint_qr_code')"></hint>
             </th>
             <td>
               <input type="file" accept="image/*" v-on:change="selectFile" />
@@ -15,8 +15,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.ImportConfigModal.label_proxy_uri') }}
-              <hint v-html="$t('components.ImportConfigModal.hint_proxy_uri')"></hint>
+              {{ $t('com.ImportConfigModal.label_proxy_uri') }}
+              <hint v-html="$t('com.ImportConfigModal.hint_proxy_uri')"></hint>
             </th>
             <td>
               <div class="textarea-wrapper">
@@ -26,8 +26,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.ImportConfigModal.label_complete_setup') }}
-              <hint v-html="$t('components.ImportConfigModal.hint_complete_setup')"></hint>
+              {{ $t('com.ImportConfigModal.label_complete_setup') }}
+              <hint v-html="$t('com.ImportConfigModal.hint_complete_setup')"></hint>
             </th>
             <td>
               <input type="checkbox" v-model="completeSetup" />
@@ -37,8 +37,8 @@
         <tbody v-show="completeSetup">
           <tr>
             <th>
-              {{ $t('components.ImportConfigModal.label_unblock') }}
-              <hint v-html="$t('components.ImportConfigModal.hint_unblock')"></hint>
+              {{ $t('com.ImportConfigModal.label_unblock') }}
+              <hint v-html="$t('com.ImportConfigModal.hint_unblock')"></hint>
             </th>
             <td class="flex-checkbox">
               <div v-for="(opt, index) in unblockItemsList" :key="index">
@@ -49,8 +49,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.ImportConfigModal.label_dont_break') }}
-              <hint v-html="$t('components.ImportConfigModal.hint_dont_break')"></hint>
+              {{ $t('com.ImportConfigModal.label_dont_break') }}
+              <hint v-html="$t('com.ImportConfigModal.hint_dont_break')"></hint>
             </th>
             <td>
               <input type="checkbox" v-model="bypassMode" />

--- a/src/components/modals/PolicyModal.vue
+++ b/src/components/modals/PolicyModal.vue
@@ -1,9 +1,9 @@
 <template>
-  <modal width="755" ref="modalList" :title="$t('components.PolicyModal.modal_title')">
+  <modal width="755" ref="modalList" :title="$t('com.PolicyModal.modal_title')">
     <table class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="4">{{ $t('components.PolicyModal.modal_title2') }}</td>
+          <td colspan="4">{{ $t('com.PolicyModal.modal_title2') }}</td>
         </tr>
       </thead>
       <tbody v-if="policies!.length > 0">
@@ -11,7 +11,7 @@
           <th>
             <label>
               <input type="checkbox" v-model="r.enabled" @change.prevent="on_off_rule(r, index)" />
-              {{ $t('components.PolicyModal.rule_no', [index + 1]) }}
+              {{ $t('com.PolicyModal.rule_no', [index + 1]) }}
             </label>
           </th>
           <td style="color: #ffcc00">{{ r.name }}</td>
@@ -27,7 +27,7 @@
       </tbody>
       <tbody v-else>
         <tr>
-          <td colspan="4" style="color: #ffcc00">{{ $t('components.PolicyModal.no_rules_defined') }}</td>
+          <td colspan="4" style="color: #ffcc00">{{ $t('com.PolicyModal.no_rules_defined') }}</td>
         </tr>
       </tbody>
     </table>
@@ -40,8 +40,8 @@
       <tbody>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_friendly_name') }}
-            <hint v-html="$t('components.PolicyModal.hint_friendly_name')"></hint>
+            {{ $t('com.PolicyModal.label_friendly_name') }}
+            <hint v-html="$t('com.PolicyModal.hint_friendly_name')"></hint>
           </th>
           <td>
             <input v-model="currentRule.name" type="text" class="input_25_table" />
@@ -49,8 +49,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_mode') }}
-            <hint v-html="$t('components.PolicyModal.hint_mode')"></hint>
+            {{ $t('com.PolicyModal.label_mode') }}
+            <hint v-html="$t('com.PolicyModal.hint_mode')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="currentRule.mode">
@@ -62,20 +62,20 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_mac') }}
-            <hint v-html="$t('components.PolicyModal.hint_mac')"></hint>
+            {{ $t('com.PolicyModal.label_mac') }}
+            <hint v-html="$t('com.PolicyModal.hint_mac')"></hint>
             <br />
             <div class="hint-color" v-show="currentRule.mode == 'redirect'">
-              {{ $t('components.PolicyModal.hint_bypass_devices') }}
+              {{ $t('com.PolicyModal.hint_bypass_devices') }}
             </div>
             <div class="hint-color" v-show="currentRule.mode == 'bypass'">
-              {{ $t('components.PolicyModal.hint_redirect_devices') }}
+              {{ $t('com.PolicyModal.hint_redirect_devices') }}
             </div>
           </th>
           <td class="flex-checkbox flex-checkbox-50 height-overflow" style="max-height: 240px">
             <label>
               <input type="checkbox" v-model="showAll" />
-              {{ $t('components.PolicyModal.label_show_all') }}
+              {{ $t('com.PolicyModal.label_show_all') }}
             </label>
             <label v-if="devices.length > 10">
               <input type="text" v-model="deviceFilter" class="input_15_table" placeholder="filter devices" @input="applyDeviceFilter" />
@@ -88,7 +88,7 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_wellknown_ports') }}
+            {{ $t('com.PolicyModal.label_wellknown_ports') }}
           </th>
           <td>
             <select v-model="vendor" class="input_option" @change="vendorChange">
@@ -101,14 +101,14 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_tcp_ports') }}
-            <hint v-html="$t('components.PolicyModal.hint_tcp_ports')"></hint>
+            {{ $t('com.PolicyModal.label_tcp_ports') }}
+            <hint v-html="$t('com.PolicyModal.hint_tcp_ports')"></hint>
             <br />
             <div class="hint-color" v-show="currentRule.mode == 'bypass'">
-              {{ $t('components.PolicyModal.hint_bypass') }}
+              {{ $t('com.PolicyModal.hint_bypass') }}
             </div>
             <div class="hint-color" v-show="currentRule.mode == 'redirect'">
-              {{ $t('components.PolicyModal.hint_redirect') }}
+              {{ $t('com.PolicyModal.hint_redirect') }}
             </div>
           </th>
           <td>
@@ -117,14 +117,14 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.PolicyModal.label_udp_ports') }}
-            <hint v-html="$t('components.PolicyModal.hint_udp_ports')"></hint>
+            {{ $t('com.PolicyModal.label_udp_ports') }}
+            <hint v-html="$t('com.PolicyModal.hint_udp_ports')"></hint>
             <br />
             <div class="hint-color" v-show="currentRule.mode == 'bypass'">
-              {{ $t('components.PolicyModal.hint_bypass') }}
+              {{ $t('com.PolicyModal.hint_bypass') }}
             </div>
             <div class="hint-color" v-show="currentRule.mode == 'redirect'">
-              {{ $t('components.PolicyModal.hint_redirect') }}
+              {{ $t('com.PolicyModal.hint_redirect') }}
             </div>
           </th>
           <td>

--- a/src/components/modals/ReverseItemsModal.vue
+++ b/src/components/modals/ReverseItemsModal.vue
@@ -1,9 +1,9 @@
 <template>
-  <modal width="450" ref="modalList" :title="$t('components.ReverseItemsModal.modal_title')">
+  <modal width="450" ref="modalList" :title="$t('com.ReverseItemsModal.modal_title')">
     <table class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="3">{{ $t('components.ReverseItemsModal.modal_title2') }}</td>
+          <td colspan="3">{{ $t('com.ReverseItemsModal.modal_title2') }}</td>
         </tr>
       </thead>
       <tbody>

--- a/src/components/modals/RulesModal.vue
+++ b/src/components/modals/RulesModal.vue
@@ -1,9 +1,9 @@
 <template>
-  <modal width="755" ref="modalList" :title="$t('components.RulesModal.modal_title')">
+  <modal width="755" ref="modalList" :title="$t('com.RulesModal.modal_title')">
     <table class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="4">{{ $t('components.RulesModal.modal_title2') }}</td>
+          <td colspan="4">{{ $t('com.RulesModal.modal_title2') }}</td>
         </tr>
       </thead>
       <tbody v-if="allRules.length">
@@ -11,7 +11,7 @@
           <th>
             <label>
               <input type="checkbox" v-model="r.enabled" @change.prevent="on_off_rule(r, index)" />
-              {{ $t('components.RulesModal.rule_no', [index + 1]) }}
+              {{ $t('com.RulesModal.rule_no', [index + 1]) }}
             </label>
           </th>
           <td style="color: #ffcc00">{{ !r.name || r.name == '' ? getRuleName(r) : r.name }}</td>
@@ -28,12 +28,12 @@
       </tbody>
       <tbody v-else>
         <tr>
-          <td colspan="4" style="color: #ffcc00">{{ $t('components.RulesModal.no_rules_defined') }}</td>
+          <td colspan="4" style="color: #ffcc00">{{ $t('com.RulesModal.no_rules_defined') }}</td>
         </tr>
       </tbody>
     </table>
     <template v-slot:footer>
-      <input class="button_gen button_gen_small" type="button" :value="$t('components.RulesModal.add_new_rule')" @click.prevent="addRule" />
+      <input class="button_gen button_gen_small" type="button" :value="$t('com.RulesModal.add_new_rule')" @click.prevent="addRule" />
     </template>
   </modal>
   <modal width="755" ref="modalAdd" title="Rule">
@@ -41,8 +41,8 @@
       <tbody>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_friendly_name') }}
-            <hint v-html="$t('components.RulesModal.hint_friendly_name')"></hint>
+            {{ $t('com.RulesModal.label_friendly_name') }}
+            <hint v-html="$t('com.RulesModal.hint_friendly_name')"></hint>
           </th>
           <td>
             <input v-model="currentRule.name" type="text" class="input_25_table" :readonly="currentRule.isSystem()" />
@@ -51,8 +51,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_outbound_tag') }}
-            <hint v-html="$t('components.RulesModal.hint_outbound_tag')"></hint>
+            {{ $t('com.RulesModal.label_outbound_tag') }}
+            <hint v-html="$t('com.RulesModal.hint_outbound_tag')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="currentRule.outboundTag">
@@ -65,8 +65,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_inbound_tags') }}
-            <hint v-html="$t('components.RulesModal.hint_inbound_tags')"></hint>
+            {{ $t('com.RulesModal.label_inbound_tags') }}
+            <hint v-html="$t('com.RulesModal.hint_inbound_tags')"></hint>
           </th>
           <td>
             <div v-for="(opt, index) in inbounds" :key="index">
@@ -79,8 +79,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_users') }}
-            <hint v-html="$t('components.RulesModal.hint_users')"></hint>
+            {{ $t('com.RulesModal.label_users') }}
+            <hint v-html="$t('com.RulesModal.hint_users')"></hint>
           </th>
           <td class="flex-checkbox">
             <div v-for="(opt, index) in users" :key="index">
@@ -93,8 +93,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_domain_matcher') }}
-            <hint v-html="$t('components.RulesModal.hint_domain_matcher')"></hint>
+            {{ $t('com.RulesModal.label_domain_matcher') }}
+            <hint v-html="$t('com.RulesModal.hint_domain_matcher')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="currentRule.domainMatcher">
@@ -107,8 +107,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_network') }}
-            <hint v-html="$t('components.RulesModal.hint_network')"></hint>
+            {{ $t('com.RulesModal.label_network') }}
+            <hint v-html="$t('com.RulesModal.hint_network')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="currentRule.network">
@@ -121,8 +121,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_protocols') }}
-            <hint v-html="$t('components.RulesModal.hint_protocols')"></hint>
+            {{ $t('com.RulesModal.label_protocols') }}
+            <hint v-html="$t('com.RulesModal.hint_protocols')"></hint>
           </th>
           <td>
             <div v-for="(opt, index) in protocolOptions" :key="index">
@@ -135,8 +135,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_domains') }}
-            <hint v-html="$t('components.RulesModal.hint_domains')"></hint>
+            {{ $t('com.RulesModal.label_domains') }}
+            <hint v-html="$t('com.RulesModal.hint_domains')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">
@@ -146,8 +146,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_target_ips') }}
-            <hint v-html="$t('components.RulesModal.hint_target_ips')"></hint>
+            {{ $t('com.RulesModal.label_target_ips') }}
+            <hint v-html="$t('com.RulesModal.hint_target_ips')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">
@@ -157,8 +157,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_target_ports') }}
-            <hint v-html="$t('components.RulesModal.hint_target_ports')"></hint>
+            {{ $t('com.RulesModal.label_target_ports') }}
+            <hint v-html="$t('com.RulesModal.hint_target_ports')"></hint>
           </th>
           <td>
             <input v-model="currentRule.port" type="text" class="input_25_table" />
@@ -167,8 +167,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_source_ips') }}
-            <hint v-html="$t('components.RulesModal.hint_source_ips')"></hint>
+            {{ $t('com.RulesModal.label_source_ips') }}
+            <hint v-html="$t('com.RulesModal.hint_source_ips')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">
@@ -179,8 +179,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.RulesModal.label_source_ports') }}
-            <hint v-html="$t('components.RulesModal.hint_source_ports')"></hint>
+            {{ $t('com.RulesModal.label_source_ports') }}
+            <hint v-html="$t('com.RulesModal.hint_source_ports')"></hint>
           </th>
           <td>
             <input v-model="currentRule.sourcePort" type="text" class="input_25_table" />
@@ -246,7 +246,7 @@
         const arr = rule.enabled ? rules : disabledRules;
         const index = arr.value.indexOf(rule);
 
-        if (!confirm(t('components.RulesModal.alert_delete_rule_confirm'))) return;
+        if (!confirm(t('com.RulesModal.alert_delete_rule_confirm'))) return;
 
         arr.value.splice(index, 1);
         emit('update:rules', rules.value);

--- a/src/components/modals/SniffingModal.vue
+++ b/src/components/modals/SniffingModal.vue
@@ -1,18 +1,18 @@
 <template>
-  <modal ref="modal" :title="$t('components.SniffingModal.modal_title')" width="500">
+  <modal ref="modal" :title="$t('com.SniffingModal.modal_title')" width="500">
     <div class="formfontdesc">
-      <p>{{ $t('components.SniffingModal.modal_desc') }}</p>
+      <p>{{ $t('com.SniffingModal.modal_desc') }}</p>
       <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
         <thead>
           <tr>
-            <td colspan="2">{{ $t('components.SniffingModal.label_settings') }}</td>
+            <td colspan="2">{{ $t('com.SniffingModal.label_settings') }}</td>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>
-              {{ $t('components.SniffingModal.label_enabled') }}
-              <hint v-html="$t('components.SniffingModal.hint_enabled')"></hint>
+              {{ $t('com.SniffingModal.label_enabled') }}
+              <hint v-html="$t('com.SniffingModal.hint_enabled')"></hint>
             </th>
             <td>
               <input type="radio" v-model="sniffing.enabled" class="input" :value="true" :id="'snifon'" />
@@ -23,8 +23,8 @@
           </tr>
           <tr v-if="sniffing.enabled">
             <th>
-              {{ $t('components.SniffingModal.label_metadata_only') }}
-              <hint v-html="$t('components.SniffingModal.hint_metadata_only')"></hint>
+              {{ $t('com.SniffingModal.label_metadata_only') }}
+              <hint v-html="$t('com.SniffingModal.hint_metadata_only')"></hint>
             </th>
             <td>
               <input type="radio" v-model="sniffing.metadataOnly" class="input" :value="true" :id="'metaon'" />
@@ -35,8 +35,8 @@
           </tr>
           <tr v-if="sniffing.enabled && !sniffing.metadataOnly">
             <th>
-              {{ $t('components.SniffingModal.label_dest_override') }}
-              <hint v-html="$t('components.SniffingModal.hint_dest_override')"></hint>
+              {{ $t('com.SniffingModal.label_dest_override') }}
+              <hint v-html="$t('com.SniffingModal.hint_dest_override')"></hint>
             </th>
             <td>
               <slot v-for="(opt, index) in destOptions" :key="index">
@@ -47,8 +47,8 @@
           </tr>
           <tr v-if="sniffing.enabled && sniffing.destOverride && sniffing.destOverride.length > 0">
             <th>
-              {{ $t('components.SniffingModal.label_route_only') }}
-              <hint v-html="$t('components.SniffingModal.hint_route_only')"></hint>
+              {{ $t('com.SniffingModal.label_route_only') }}
+              <hint v-html="$t('com.SniffingModal.hint_route_only')"></hint>
             </th>
             <td>
               <input type="checkbox" v-model="sniffing.routeOnly" class="input" :id="'snifrouteonly'" />
@@ -57,15 +57,15 @@
           </tr>
           <tr v-if="sniffing.enabled">
             <th>
-              {{ $t('components.SniffingModal.label_domains_excluded') }}
-              <hint v-html="$t('components.SniffingModal.hint_domains_excluded')"></hint>
+              {{ $t('com.SniffingModal.label_domains_excluded') }}
+              <hint v-html="$t('com.SniffingModal.hint_domains_excluded')"></hint>
             </th>
             <td>
               <a v-if="sniffing.domainsExcluded">{{ $t('labels.items', [sniffing.domainsExcluded.length]) }}</a>
               <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click.prevent="manage_domains_exclude" />
-              <modal width="500" ref="modalDomains" :title="$t('components.SniffingModal.modal_domains_title')">
+              <modal width="500" ref="modalDomains" :title="$t('com.SniffingModal.modal_domains_title')">
                 <div class="formfontdesc">
-                  <p>{{ $t('components.SniffingModal.modal_domains_desc') }}</p>
+                  <p>{{ $t('com.SniffingModal.modal_domains_desc') }}</p>
                   <div class="textarea-wrapper">
                     <textarea v-model="domainsExludedContent" class="input_100" rows="8"></textarea>
                   </div>

--- a/src/components/modals/StreamSettingsModal.vue
+++ b/src/components/modals/StreamSettingsModal.vue
@@ -1,20 +1,20 @@
 <template>
-  <modal ref="modal" :title="$t('components.StreamSettingsModal.modal_title')">
+  <modal ref="modal" :title="$t('com.StreamSettingsModal.modal_title')">
     <div class="formfontdesc">
-      <p v-html="$t('components.StreamSettingsModal.modal_desc')"></p>
+      <p v-html="$t('com.StreamSettingsModal.modal_desc')"></p>
       <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
         <thead>
           <tr>
             <td colspan="2">
-              {{ $t('components.StreamSettingsModal.title') }}
+              {{ $t('com.StreamSettingsModal.title') }}
             </td>
           </tr>
         </thead>
         <tbody>
           <tr>
             <th>
-              {{ $t('components.StreamSettingsModal.label_security') }}
-              <hint v-html="$t('components.StreamSettingsModal.hint_security')"></hint>
+              {{ $t('com.StreamSettingsModal.label_security') }}
+              <hint v-html="$t('com.StreamSettingsModal.hint_security')"></hint>
             </th>
             <td>
               <select class="input_option" v-model="transport.security">
@@ -23,15 +23,15 @@
               <span class="row-buttons" v-if="transport.security != 'none'">
                 <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click="manage_security" />
               </span>
-              <modal ref="securityModal" :title="$t('components.StreamSettingsModal.modal_security_title')" v-if="transport.security != 'none'">
+              <modal ref="securityModal" :title="$t('com.StreamSettingsModal.modal_security_title')" v-if="transport.security != 'none'">
                 <component :is="securityComponent" :transport="transport" v-model:proxyType="proxyType" />
               </modal>
             </td>
           </tr>
           <tr>
             <th>
-              {{ $t('components.StreamSettingsModal.label_network') }}
-              <hint v-html="$t('components.StreamSettingsModal.hint_network')"></hint>
+              {{ $t('com.StreamSettingsModal.label_network') }}
+              <hint v-html="$t('com.StreamSettingsModal.hint_network')"></hint>
             </th>
             <td>
               <select class="input_option" v-model="transport.network">
@@ -42,8 +42,8 @@
           </tr>
           <tr>
             <th>
-              {{ $t('components.StreamSettingsModal.label_tproxy') }}
-              <hint v-html="$t('components.StreamSettingsModal.hint_tproxy')"></hint>
+              {{ $t('com.StreamSettingsModal.label_tproxy') }}
+              <hint v-html="$t('com.StreamSettingsModal.hint_tproxy')"></hint>
             </th>
             <td>
               <span class="row-buttons">

--- a/src/components/modals/XrayCoreVersionModal.vue
+++ b/src/components/modals/XrayCoreVersionModal.vue
@@ -1,7 +1,7 @@
 <template>
-  <modal ref="modal" :title="$t('components.XrayCoreVersionModal.modal_title')" width="300">
+  <modal ref="modal" :title="$t('com.XrayCoreVersionModal.modal_title')" width="300">
     <div class="formfontdesc">
-      <p>{{ $t('components.XrayCoreVersionModal.modal_desc') }}</p>
+      <p>{{ $t('com.XrayCoreVersionModal.modal_desc') }}</p>
       <p>
         <select class="input_option" v-model="selected_url">
           <option v-for="(opt, index) in xray_versions" :key="index" :value="opt.url">
@@ -11,7 +11,7 @@
       </p>
     </div>
     <template #footer>
-      <input class="button_gen button_gen_small" type="button" :value="$t('components.XrayCoreVersionModal.switch')" @click.prevent="switch_version" />
+      <input class="button_gen button_gen_small" type="button" :value="$t('com.XrayCoreVersionModal.switch')" @click.prevent="switch_version" />
     </template>
   </modal>
 </template>
@@ -74,7 +74,7 @@
 
       const switch_version = async () => {
         if (!selected_url.value) {
-          alert(t('components.XrayCoreVersionModal.error_no_version_selected'));
+          alert(t('com.XrayCoreVersionModal.error_no_version_selected'));
           return;
         }
         await engine.executeWithLoadingProgress(async () => {

--- a/src/components/outbounds/BlackholeOutbound.vue
+++ b/src/components/outbounds/BlackholeOutbound.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="formfontdesc">
-    <p>{{ $t('components.BlackholeOutbound.modal_desc') }}</p>
+    <p>{{ $t('com.BlackholeOutbound.modal_desc') }}</p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.BlackholeOutbound.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.BlackholeOutbound.modal_title') }}</td>
         </tr>
       </thead>
       <tbody>
         <outbound-common :proxy="proxy"></outbound-common>
         <tr v-if="proxy.settings.response">
           <th>
-            {{ $t('components.BlackholeOutbound.label_response') }}
-            <hint v-html="$t('components.BlackholeOutbound.hint_response')"></hint>
+            {{ $t('com.BlackholeOutbound.label_response') }}
+            <hint v-html="$t('com.BlackholeOutbound.hint_response')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="proxy.settings.response.type">

--- a/src/components/outbounds/FreedomOutbound.vue
+++ b/src/components/outbounds/FreedomOutbound.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="formfontdesc">
-    <p>{{ $t('components.FreedomOutbound.modal_desc') }}</p>
+    <p>{{ $t('com.FreedomOutbound.modal_desc') }}</p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.FreedomOutbound.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.FreedomOutbound.modal_title') }}</td>
         </tr>
       </thead>
       <tbody>
         <outbound-common :proxy="proxy"></outbound-common>
         <tr>
           <th>
-            {{ $t('components.FreedomOutbound.label_domain_strategy') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_domain_strategy')"></hint>
+            {{ $t('com.FreedomOutbound.label_domain_strategy') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_domain_strategy')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="proxy.settings.domainStrategy">
@@ -26,8 +26,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.FreedomOutbound.label_redirect') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_redirect')"></hint>
+            {{ $t('com.FreedomOutbound.label_redirect') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_redirect')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="proxy.settings.redirect" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -36,8 +36,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.FreedomOutbound.label_proxy_protocol') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_proxy_protocol')"></hint>
+            {{ $t('com.FreedomOutbound.label_proxy_protocol') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_proxy_protocol')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="proxy.settings.proxyProtocol">
@@ -52,8 +52,8 @@
       <tbody v-if="proxy.settings.fragment">
         <tr>
           <th>
-            {{ $t('components.FreedomOutbound.label_fragment') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_fragment')"></hint>
+            {{ $t('com.FreedomOutbound.label_fragment') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_fragment')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="proxy.settings.fragment.packets">
@@ -67,8 +67,8 @@
         </tr>
         <tr v-if="proxy.settings.fragment.packets !== ''">
           <th>
-            {{ $t('components.FreedomOutbound.label_fragment_length') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_fragment_length')"></hint>
+            {{ $t('com.FreedomOutbound.label_fragment_length') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_fragment_length')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="proxy.settings.fragment.length" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -76,8 +76,8 @@
         </tr>
         <tr v-if="proxy.settings.fragment.packets !== ''">
           <th>
-            {{ $t('components.FreedomOutbound.label_fragment_interval') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_fragment_interval')"></hint>
+            {{ $t('com.FreedomOutbound.label_fragment_interval') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_fragment_interval')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="proxy.settings.fragment.interval" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -87,13 +87,13 @@
       <tbody v-if="proxy.settings.noises">
         <tr>
           <th>
-            {{ $t('components.FreedomOutbound.label_udp_noise') }}
-            <hint v-html="$t('components.FreedomOutbound.hint_udp_noise')"></hint>
+            {{ $t('com.FreedomOutbound.label_udp_noise') }}
+            <hint v-html="$t('com.FreedomOutbound.hint_udp_noise')"></hint>
           </th>
           <td>
             {{ $t('labels.items', [proxy.settings.noises.length]) }}
             <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click.prevent="manage_noises" />
-            <modal width="500" ref="modalNoises" :title="$t('components.FreedomOutbound.modal_udp_noise_title')">
+            <modal width="500" ref="modalNoises" :title="$t('com.FreedomOutbound.modal_udp_noise_title')">
               <table class="FormTable modal-form-table">
                 <tbody>
                   <tr v-for="(noise, index) in proxy.settings.noises" :key="index">
@@ -113,13 +113,13 @@
                 <input class="button_gen button_gen_small" type="button" :value="$t('labels.close')" @click.prevent="modal_noises_close()" />
               </template>
             </modal>
-            <modal width="400" ref="modalNoise" :title="$t('components.FreedomOutbound.modal_udp_noise_entry_title')">
+            <modal width="400" ref="modalNoise" :title="$t('com.FreedomOutbound.modal_udp_noise_entry_title')">
               <table class="FormTable modal-form-table" v-if="noiseItem">
                 <tbody>
                   <tr>
                     <th>
-                      {{ $t('components.FreedomOutbound.label_udp_noise_type') }}
-                      <hint v-html="$t('components.FreedomOutbound.hint_udp_noise_type')"></hint>
+                      {{ $t('com.FreedomOutbound.label_udp_noise_type') }}
+                      <hint v-html="$t('com.FreedomOutbound.hint_udp_noise_type')"></hint>
                     </th>
                     <td>
                       <select class="input_option" v-model="noiseItem.type">
@@ -131,8 +131,8 @@
                   </tr>
                   <tr>
                     <th>
-                      {{ $t('components.FreedomOutbound.label_udp_noise_packet') }}
-                      <hint v-html="$t('components.FreedomOutbound.hint_udp_noise_packet')"> </hint>
+                      {{ $t('com.FreedomOutbound.label_udp_noise_packet') }}
+                      <hint v-html="$t('com.FreedomOutbound.hint_udp_noise_packet')"> </hint>
                     </th>
                     <td>
                       <input type="text" class="input_20_table" v-model="noiseItem.packet" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -140,8 +140,8 @@
                   </tr>
                   <tr>
                     <th>
-                      {{ $t('components.FreedomOutbound.label_udp_noise_delay') }}
-                      <hint v-html="$t('components.FreedomOutbound.hint_udp_noise_delay')"></hint>
+                      {{ $t('com.FreedomOutbound.label_udp_noise_delay') }}
+                      <hint v-html="$t('com.FreedomOutbound.hint_udp_noise_delay')"></hint>
                     </th>
                     <td>
                       <input type="text" class="input_20_table" v-model="noiseItem.delay" autocomplete="off" autocorrect="off" autocapitalize="off" />

--- a/src/components/outbounds/OutboundCommon.vue
+++ b/src/components/outbounds/OutboundCommon.vue
@@ -1,8 +1,8 @@
 <template>
   <tr>
     <th>
-      {{ $t('components.OutboundCommon.label_tag') }}
-      <hint v-html="$t('components.OutboundCommon.hint_tag')"></hint>
+      {{ $t('com.OutboundCommon.label_tag') }}
+      <hint v-html="$t('com.OutboundCommon.hint_tag')"></hint>
     </th>
     <td>
       <input type="text" class="input_20_table" v-model="proxy.tag" />
@@ -11,8 +11,8 @@
   </tr>
   <tr>
     <th>
-      {{ $t('components.OutboundCommon.label_send_through') }}
-      <hint v-html="$t('components.OutboundCommon.hint_send_through')"></hint>
+      {{ $t('com.OutboundCommon.label_send_through') }}
+      <hint v-html="$t('com.OutboundCommon.hint_send_through')"></hint>
     </th>
     <td>
       <input type="text" class="input_20_table" v-model="proxy.sendThrough" autocomplete="off" autocorrect="off" autocapitalize="off" />

--- a/src/components/outbounds/VlessOutbound.vue
+++ b/src/components/outbounds/VlessOutbound.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="formfontdesc">
-    <p>{{ $t('components.VlessOutbound.modal_desc') }}</p>
+    <p>{{ $t('com.VlessOutbound.modal_desc') }}</p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.VlessOutbound.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.VlessOutbound.modal_title') }}</td>
         </tr>
       </thead>
       <tbody>
         <outbound-common :proxy="proxy"></outbound-common>
         <tr>
           <th>
-            {{ $t('components.VlessOutbound.label_address') }}
-            <hint v-html="$t('components.VlessOutbound.hint_address')"></hint>
+            {{ $t('com.VlessOutbound.label_address') }}
+            <hint v-html="$t('com.VlessOutbound.hint_address')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="proxy.settings.vnext[0].address" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -21,8 +21,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.VlessOutbound.label_port') }}
-            <hint v-html="$t('components.VlessOutbound.hint_port')"></hint>
+            {{ $t('com.VlessOutbound.label_port') }}
+            <hint v-html="$t('com.VlessOutbound.hint_port')"></hint>
           </th>
           <td>
             <input type="number" maxlength="5" class="input_6_table" v-model="proxy.settings.vnext[0].port" autocorrect="off" autocapitalize="off" onkeypress="return validator.isNumber(this,event);" />

--- a/src/components/outbounds/VmessOutbound.vue
+++ b/src/components/outbounds/VmessOutbound.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="formfontdesc">
-    <p v-html="$t('components.VmessOutbound.modal_desc')"></p>
+    <p v-html="$t('com.VmessOutbound.modal_desc')"></p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2" v-html="$t('components.VmessOutbound.modal_title')"></td>
+          <td colspan="2" v-html="$t('com.VmessOutbound.modal_title')"></td>
         </tr>
       </thead>
       <tbody>
         <outbound-common :proxy="proxy"></outbound-common>
         <tr>
           <th>
-            {{ $t('components.VmessOutbound.label_address') }}
-            <hint v-html="$t('components.VlessOutbound.hint_address')"></hint>
+            {{ $t('com.VmessOutbound.label_address') }}
+            <hint v-html="$t('com.VlessOutbound.hint_address')"></hint>
           </th>
           <td>
             <input type="text" class="input_20_table" v-model="proxy.settings.vnext[0].address" autocomplete="off" autocorrect="off" autocapitalize="off" />
@@ -21,8 +21,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.VmessOutbound.label_port') }}
-            <hint v-html="$t('components.VmessOutbound.hint_port')"></hint>
+            {{ $t('com.VmessOutbound.label_port') }}
+            <hint v-html="$t('com.VmessOutbound.hint_port')"></hint>
           </th>
           <td>
             <input type="number" maxlength="5" class="input_6_table" v-model="proxy.settings.vnext[0].port" autocorrect="off" autocapitalize="off" onkeypress="return validator.isNumber(this,event);" />

--- a/src/components/security/Reality.vue
+++ b/src/components/security/Reality.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="formfontdesc">
-    <p v-html="$t('components.Reality.modal_desc')"></p>
+    <p v-html="$t('com.Reality.modal_desc')"></p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.Reality.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.Reality.modal_title') }}</td>
         </tr>
       </thead>
       <tbody v-if="transport.realitySettings">
         <tr>
           <th>
-            {{ $t('components.Reality.label_enable_logs') }}
-            <hint v-html="$t('components.Reality.hint_enable_logs')"></hint>
+            {{ $t('com.Reality.label_enable_logs') }}
+            <hint v-html="$t('com.Reality.hint_enable_logs')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.show" type="checkbox" class="input" />
@@ -20,8 +20,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Reality.label_dest') }}
-            <hint v-html="$t('components.Reality.hint_dest')"></hint>
+            {{ $t('com.Reality.label_dest') }}
+            <hint v-html="$t('com.Reality.hint_dest')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.dest" type="text" class="input_20_table" />
@@ -29,8 +29,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Reality.label_server_names') }}
-            <hint v-html="$t('components.Reality.hint_server_names')"></hint>
+            {{ $t('com.Reality.label_server_names') }}
+            <hint v-html="$t('com.Reality.hint_server_names')"></hint>
           </th>
           <td>
             <div class="textarea-wrapper">
@@ -40,8 +40,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Reality.label_server_name') }}
-            <hint v-html="$t('components.Reality.hint_server_name')"></hint>
+            {{ $t('com.Reality.label_server_name') }}
+            <hint v-html="$t('com.Reality.hint_server_name')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.serverName" type="text" class="input_20_table" />
@@ -50,8 +50,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Reality.label_short_id') }}
-            <hint v-html="$t('components.Reality.hint_short_id')"></hint>
+            {{ $t('com.Reality.label_short_id') }}
+            <hint v-html="$t('com.Reality.hint_short_id')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.shortId" type="text" class="input_20_table" />
@@ -60,8 +60,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound' && transport.realitySettings.shortIds">
           <th>
-            {{ $t('components.Reality.label_short_ids') }}
-            <hint v-html="$t('components.Reality.hint_short_ids')"></hint>
+            {{ $t('com.Reality.label_short_ids') }}
+            <hint v-html="$t('com.Reality.hint_short_ids')"></hint>
           </th>
           <td>
             {{ transport.realitySettings.shortIds.length }} item(s)
@@ -71,7 +71,7 @@
                 <textarea v-model="shortIds"></textarea>
               </div>
               <template v-slot:footer>
-                <input class="button_gen button_gen_small" type="button" :value="$t('components.Reality.add_new_id')" @click.prevent="append_shortid()" />
+                <input class="button_gen button_gen_small" type="button" :value="$t('com.Reality.add_new_id')" @click.prevent="append_shortid()" />
                 <input class="button_gen button_gen_small" type="button" :value="$t('labels.save')" @click.prevent="shortIdsModal.close()" />
               </template>
             </modal>
@@ -79,8 +79,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Reality.label_proxy_version') }}
-            <hint v-html="$t('components.Reality.hint_proxy_version')"></hint>
+            {{ $t('com.Reality.label_proxy_version') }}
+            <hint v-html="$t('com.Reality.hint_proxy_version')"></hint>
           </th>
           <td>
             <select v-model="transport.realitySettings.xver" class="input_option">
@@ -93,8 +93,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Reality.label_private_key') }}
-            <hint v-html="$t('components.Reality.hintl_private_key')"></hint>
+            {{ $t('com.Reality.label_private_key') }}
+            <hint v-html="$t('com.Reality.hintl_private_key')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.privateKey" type="text" class="input_30_table" />
@@ -105,8 +105,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.Reality.label_public_key') }}
-            <hint v-html="$t('components.Reality.hint_public_key')"></hint>
+            {{ $t('com.Reality.label_public_key') }}
+            <hint v-html="$t('com.Reality.hint_public_key')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.publicKey" type="text" class="input_30_table" />
@@ -114,8 +114,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.Reality.label_spider_x') }}
-            <hint v-html="$t('components.Reality.hint_spider_x')"></hint>
+            {{ $t('com.Reality.label_spider_x') }}
+            <hint v-html="$t('com.Reality.hint_spider_x')"></hint>
           </th>
           <td>
             <input v-model="transport.realitySettings.spiderX" type="text" class="input_30_table" />
@@ -123,8 +123,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Reality.label_fingerprint') }}
-            <hint v-html="$t('components.Reality.hint_fingerprint')"></hint>
+            {{ $t('com.Reality.label_fingerprint') }}
+            <hint v-html="$t('com.Reality.hint_fingerprint')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="transport.realitySettings.fingerprint">

--- a/src/components/security/Tls.vue
+++ b/src/components/security/Tls.vue
@@ -1,17 +1,17 @@
 <template>
   <div class="formfontdesc">
-    <p>{{ $t('components.Tls.modal_desc') }}</p>
+    <p>{{ $t('com.Tls.modal_desc') }}</p>
     <table width="100%" bordercolor="#6b8fa3" class="FormTable modal-form-table">
       <thead>
         <tr>
-          <td colspan="2">{{ $t('components.Tls.modal_title') }}</td>
+          <td colspan="2">{{ $t('com.Tls.modal_title') }}</td>
         </tr>
       </thead>
       <tbody v-if="transport.tlsSettings">
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Tls.label_server_name') }}
-            <hint v-html="$t('components.Tls.hint_server_name')"></hint>
+            {{ $t('com.Tls.label_server_name') }}
+            <hint v-html="$t('com.Tls.hint_server_name')"></hint>
           </th>
           <td>
             <input v-model="transport.tlsSettings.serverName" type="text" class="input_20_table" />
@@ -20,8 +20,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Tls.label_allow_insecure') }}
-            <hint v-html="$t('components.Tls.hint_allow_insecure')"></hint>
+            {{ $t('com.Tls.label_allow_insecure') }}
+            <hint v-html="$t('com.Tls.hint_allow_insecure')"></hint>
           </th>
           <td>
             <input v-model="transport.tlsSettings.allowInsecure" type="checkbox" class="input" />
@@ -30,8 +30,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Tls.label_reject_unknown_sni') }}
-            <hint v-html="$t('components.Tls.hint_reject_unknown_sni')"></hint>
+            {{ $t('com.Tls.label_reject_unknown_sni') }}
+            <hint v-html="$t('com.Tls.hint_reject_unknown_sni')"></hint>
           </th>
           <td>
             <input v-model="transport.tlsSettings.rejectUnknownSni" type="checkbox" class="input" />
@@ -40,8 +40,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.Tls.label_dont_use_ca') }}
-            <hint v-html="$t('components.Tls.hint_dont_use_ca')"></hint>
+            {{ $t('com.Tls.label_dont_use_ca') }}
+            <hint v-html="$t('com.Tls.hint_dont_use_ca')"></hint>
           </th>
           <td>
             <input v-model="transport.tlsSettings.disableSystemRoot" type="checkbox" class="input" />
@@ -50,8 +50,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Tls.label_session_resumption') }}
-            <hint v-html="$t('components.Tls.hint_session_resumption')"></hint>
+            {{ $t('com.Tls.label_session_resumption') }}
+            <hint v-html="$t('com.Tls.hint_session_resumption')"></hint>
           </th>
           <td>
             <input v-model="transport.tlsSettings.enableSessionResumption" type="checkbox" class="input" />
@@ -60,8 +60,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.Tls.label_alpn') }}
-            <hint v-html="$t('components.Tls.hint_alpn')"></hint>
+            {{ $t('com.Tls.label_alpn') }}
+            <hint v-html="$t('com.Tls.hint_alpn')"></hint>
           </th>
           <td>
             <template v-for="(opt, index) in alpnOptions" :key="index">
@@ -73,8 +73,8 @@
         </tr>
         <tr>
           <th>
-            {{ $t('components.Tls.label_tls_version') }}
-            <hint v-html="$t('components.Tls.hint_tls_version')"></hint>
+            {{ $t('com.Tls.label_tls_version') }}
+            <hint v-html="$t('com.Tls.hint_tls_version')"></hint>
           </th>
           <td>
             <select v-model="transport.tlsSettings.minVersion" class="input_option">
@@ -93,8 +93,8 @@
         </tr>
         <tr v-if="proxyType === 'outbound'">
           <th>
-            {{ $t('components.Tls.label_fingerprint') }}
-            <hint v-html="$t('components.Tls.hint_fingerprint')"></hint>
+            {{ $t('com.Tls.label_fingerprint') }}
+            <hint v-html="$t('com.Tls.hint_fingerprint')"></hint>
           </th>
           <td>
             <select class="input_option" v-model="transport.tlsSettings.fingerprint">
@@ -107,8 +107,8 @@
         </tr>
         <tr v-if="proxyType === 'inbound'">
           <th>
-            {{ $t('components.Tls.label_certificate') }}
-            <hint v-html="$t('components.Tls.hint_certificate')"></hint>
+            {{ $t('com.Tls.label_certificate') }}
+            <hint v-html="$t('com.Tls.hint_certificate')"></hint>
           </th>
           <td>
             <input class="button_gen button_gen_small" type="button" :value="$t('labels.manage')" @click.prevent="certificate_manage()" />

--- a/src/components/transport/Grpc.vue
+++ b/src/components/transport/Grpc.vue
@@ -2,8 +2,8 @@
   <tbody v-if="transport.grpcSettings">
     <tr>
       <th>
-        {{ $t('components.Grpc.label_service_name') }}
-        <hint v-html="$t('components.Grpc.hint_service_name')"></hint>
+        {{ $t('com.Grpc.label_service_name') }}
+        <hint v-html="$t('com.Grpc.hint_service_name')"></hint>
       </th>
       <td>
         <input type="text" maxlength="15" class="input_20_table" v-model="transport.grpcSettings.serviceName" />
@@ -12,8 +12,8 @@
     </tr>
     <tr v-if="isOutbound">
       <th>
-        {{ $t('components.Grpc.label_health_check') }}
-        <hint v-html="$t('components.Grpc.hint_health_check')"></hint>
+        {{ $t('com.Grpc.label_health_check') }}
+        <hint v-html="$t('com.Grpc.hint_health_check')"></hint>
       </th>
       <td>
         <input type="number" min="10" maxlength="4" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.grpcSettings.idle_timeout" />
@@ -22,8 +22,8 @@
     </tr>
     <tr v-if="isOutbound">
       <th>
-        {{ $t('components.Grpc.label_health_check_timeout') }}
-        <hint v-html="$t('components.Grpc.hint_health_check_timeout')"></hint>
+        {{ $t('com.Grpc.label_health_check_timeout') }}
+        <hint v-html="$t('com.Grpc.hint_health_check_timeout')"></hint>
       </th>
       <td>
         <input type="number" maxlength="4" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.grpcSettings.health_check_timeout" />
@@ -32,8 +32,8 @@
     </tr>
     <tr v-if="isOutbound">
       <th>
-        {{ $t('components.Grpc.label_permit_without_stream') }}
-        <hint v-html="$t('components.Grpc.hint_permit_without_stream')"></hint>
+        {{ $t('com.Grpc.label_permit_without_stream') }}
+        <hint v-html="$t('com.Grpc.hint_permit_without_stream')"></hint>
       </th>
       <td>
         <input v-model="transport.grpcSettings.permit_without_stream" type="checkbox" class="input" />
@@ -42,8 +42,8 @@
     </tr>
     <tr v-if="isOutbound">
       <th>
-        {{ $t('components.Grpc.label_initial_windows_size') }}
-        <hint v-html="$t('components.Grpc.hint_initial_windows_size')"></hint>
+        {{ $t('com.Grpc.label_initial_windows_size') }}
+        <hint v-html="$t('com.Grpc.hint_initial_windows_size')"></hint>
       </th>
       <td>
         <input type="number" maxlength="5" min="0" max="65535" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.grpcSettings.initial_windows_size" />

--- a/src/components/transport/HeadersMapping.vue
+++ b/src/components/transport/HeadersMapping.vue
@@ -1,10 +1,10 @@
 <template>
   <tr>
-    <th>{{ $t('components.HeadersMapping.label_headers_row') }}</th>
+    <th>{{ $t('com.HeadersMapping.label_headers_row') }}</th>
     <td>
       <div class="textarea-wrapper">
         <spot v-for="(obj, index) in headers" :key="index">
-          <input type="text" class="input_15_table" v-model="obj.key" :placeholder="$t('components.HeadersMapping.pl_header_key')" /> : <input type="text" class="input_20_table" v-model="obj.value" :placeholder="$t('components.HeadersMapping.pl_header_value')" />
+          <input type="text" class="input_15_table" v-model="obj.key" :placeholder="$t('com.HeadersMapping.pl_header_key')" /> : <input type="text" class="input_20_table" v-model="obj.value" :placeholder="$t('com.HeadersMapping.pl_header_value')" />
           <input class="button_gen button_gen_small" type="button" value="&#10005;" @click.prevent="remove_header(obj)" />
         </spot>
         <span class="row-buttons">

--- a/src/components/transport/HttpUpgrade.vue
+++ b/src/components/transport/HttpUpgrade.vue
@@ -2,8 +2,8 @@
   <tbody v-if="transport.httpupgradeSettings">
     <tr v-if="isInbound">
       <th>
-        {{ $t('components.HttpUpgrade.label_accept_proxy_protocol') }}
-        <hint v-html="$t('components.HttpUpgrade.hint_accept_proxy_protocol')"></hint>
+        {{ $t('com.HttpUpgrade.label_accept_proxy_protocol') }}
+        <hint v-html="$t('com.HttpUpgrade.hint_accept_proxy_protocol')"></hint>
       </th>
       <td>
         <input type="checkbox" name="xray_network_tcp_accept_proxy" class="input" v-model="transport.httpupgradeSettings.acceptProxyProtocol" />
@@ -12,8 +12,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.HttpUpgrade.label_path') }}
-        <hint v-html="$t('components.HttpUpgrade.hint_path')"></hint>
+        {{ $t('com.HttpUpgrade.label_path') }}
+        <hint v-html="$t('com.HttpUpgrade.hint_path')"></hint>
       </th>
       <td>
         <input type="text" maxlength="15" class="input_20_table" v-model="transport.httpupgradeSettings.path" />
@@ -22,8 +22,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.HttpUpgrade.label_host') }}
-        <hint v-html="$t('components.HttpUpgrade.hint_host')"></hint>
+        {{ $t('com.HttpUpgrade.label_host') }}
+        <hint v-html="$t('com.HttpUpgrade.hint_host')"></hint>
       </th>
       <td>
         <input type="text" maxlength="15" class="input_20_table" v-model="transport.httpupgradeSettings.host" />

--- a/src/components/transport/Kcp.vue
+++ b/src/components/transport/Kcp.vue
@@ -2,8 +2,8 @@
   <tbody v-if="transport.kcpSettings">
     <tr>
       <th>
-        {{ $t('components.Kcp.label_mtu') }}
-        <hint v-html="$t('components.Kcp.hint_mtu')"></hint>
+        {{ $t('com.Kcp.label_mtu') }}
+        <hint v-html="$t('com.Kcp.hint_mtu')"></hint>
       </th>
       <td>
         <input type="number" maxlength="4" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.mtu" />
@@ -12,8 +12,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_tti') }}
-        <hint v-html="$t('components.Kcp.hint_tti')"></hint>
+        {{ $t('com.Kcp.label_tti') }}
+        <hint v-html="$t('com.Kcp.hint_tti')"></hint>
       </th>
       <td>
         <input type="number" maxlength="3" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.tti" />
@@ -22,8 +22,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_uplink_capacity') }}
-        <hint v-html="$t('components.Kcp.hint_uplink_capacity')"></hint>
+        {{ $t('com.Kcp.label_uplink_capacity') }}
+        <hint v-html="$t('com.Kcp.hint_uplink_capacity')"></hint>
       </th>
       <td>
         <input type="number" maxlength="3" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.uplinkCapacity" />
@@ -32,8 +32,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_downlink_capacity') }}
-        <hint v-html="$t('components.Kcp.hint_downlink_capacity')"></hint>
+        {{ $t('com.Kcp.label_downlink_capacity') }}
+        <hint v-html="$t('com.Kcp.hint_downlink_capacity')"></hint>
       </th>
       <td>
         <input type="number" maxlength="3" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.downlinkCapacity" />
@@ -42,8 +42,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_congestion') }}
-        <hint v-html="$t('components.Kcp.hint_congestion')"></hint>
+        {{ $t('com.Kcp.label_congestion') }}
+        <hint v-html="$t('com.Kcp.hint_congestion')"></hint>
       </th>
       <td>
         <input type="checkbox" class="input" v-model="transport.kcpSettings.congestion" />
@@ -52,8 +52,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_read_buffer') }}
-        <hint v-html="$t('components.Kcp.hint_read_buffer')"></hint>
+        {{ $t('com.Kcp.label_read_buffer') }}
+        <hint v-html="$t('com.Kcp.hint_read_buffer')"></hint>
       </th>
       <td>
         <input type="number" maxlength="3" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.readBufferSize" />
@@ -62,8 +62,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_write_buffer') }}
-        <hint v-html="$t('components.Kcp.hint_write_buffer')"></hint>
+        {{ $t('com.Kcp.label_write_buffer') }}
+        <hint v-html="$t('com.Kcp.hint_write_buffer')"></hint>
       </th>
       <td>
         <input type="number" maxlength="3" class="input_6_table" onkeypress="return validator.isNumber(this,event);" v-model="transport.kcpSettings.writeBufferSize" />
@@ -72,8 +72,8 @@
     </tr>
     <tr>
       <th>
-        {{ $t('components.Kcp.label_seed') }}
-        <hint v-html="$t('components.Kcp.hint_seed')"></hint>
+        {{ $t('com.Kcp.label_seed') }}
+        <hint v-html="$t('com.Kcp.hint_seed')"></hint>
       </th>
       <td>
         <input type="text" class="input_25_table" v-model="transport.kcpSettings.seed" />
@@ -85,8 +85,8 @@
     </tr>
     <tr v-if="transport.kcpSettings.header">
       <th>
-        {{ $t('components.Kcp.label_header') }}
-        <hint v-html="$t('components.Kcp.hint_header')"></hint>
+        {{ $t('com.Kcp.label_header') }}
+        <hint v-html="$t('com.Kcp.hint_header')"></hint>
       </th>
       <td>
         <select class="input_option" v-model="transport.kcpSettings.header.type">

--- a/src/components/transport/Tcp.vue
+++ b/src/components/transport/Tcp.vue
@@ -2,8 +2,8 @@
   <tbody v-if="transport.tcpSettings">
     <tr v-if="isInbound">
       <th>
-        {{ $t('components.Tcp.label_accept_proxy_protocol') }}
-        <hint v-html="$t('components.Tcp.hint_accept_proxy_protocol')"></hint>
+        {{ $t('com.Tcp.label_accept_proxy_protocol') }}
+        <hint v-html="$t('com.Tcp.hint_accept_proxy_protocol')"></hint>
       </th>
       <td>
         <input type="checkbox" name="xray_network_tcp_accept_proxy" class="input" v-model="transport.tcpSettings.acceptProxyProtocol" />


### PR DESCRIPTION
This pull request focuses on standardizing the translation keys across multiple Vue components by updating the translation key prefixes from `components` to `com`. The changes ensure consistency and simplify the translation process.

Key changes include:

* **Translation Key Updates**:
  * [`src/components/ClientsOnline.vue`](diffhunk://#diff-8a8b51a978636cef696f8630dd7a7d8d1673d3655d661b59900c32b8a386d789L6-R30): Updated translation keys from `components.ClientsOnline` to `com.ClientsOnline`.
  * [`src/components/Dns.vue`](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L6-R15): Updated translation keys from `components.Dns` to `com.Dns`. [[1]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L6-R15) [[2]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L24-R25) [[3]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L36-R37) [[4]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L48-R49) [[5]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L58-R59) [[6]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L72-R73) [[7]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L82-R83) [[8]](diffhunk://#diff-92d0f5937e69165f65db5d6d7adbe9affa869ba04397120a320d30f30d0cce16L92-R93)
  * [`src/components/Inbounds.vue`](diffhunk://#diff-f397463b4609751a5d423753eb3f507055ada0f5b85d44e2f24786ad1627e773L5-R10): Updated translation keys from `components.Inbounds` to `com.Inbounds`. [[1]](diffhunk://#diff-f397463b4609751a5d423753eb3f507055ada0f5b85d44e2f24786ad1627e773L5-R10) [[2]](diffhunk://#diff-f397463b4609751a5d423753eb3f507055ada0f5b85d44e2f24786ad1627e773L52-R52) [[3]](diffhunk://#diff-f397463b4609751a5d423753eb3f507055ada0f5b85d44e2f24786ad1627e773L161-R169)
  * [`src/components/Outbounds.vue`](diffhunk://#diff-c88d147d76473a3db100273b7f9a7f6efb788dac2cb35728d78ecb783cf06bd5L5-R10): Updated translation keys from `components.Outbounds` to `com.Outbounds`. [[1]](diffhunk://#diff-c88d147d76473a3db100273b7f9a7f6efb788dac2cb35728d78ecb783cf06bd5L5-R10) [[2]](diffhunk://#diff-c88d147d76473a3db100273b7f9a7f6efb788dac2cb35728d78ecb783cf06bd5L141-R149)
  * [`src/components/ServiceStatus.vue`](diffhunk://#diff-ae39a2c6f102033a5b3702e67a3ccaf22b9276d1f231b6181bb291dbddceb6eeL6-R13): Updated translation keys from `components.ClientStatus` to `com.ClientStatus`. [[1]](diffhunk://#diff-ae39a2c6f102033a5b3702e67a3ccaf22b9276d1f231b6181bb291dbddceb6eeL6-R13) [[2]](diffhunk://#diff-ae39a2c6f102033a5b3702e67a3ccaf22b9276d1f231b6181bb291dbddceb6eeL33-R33) [[3]](diffhunk://#diff-ae39a2c6f102033a5b3702e67a3ccaf22b9276d1f231b6181bb291dbddceb6eeL85-R85)

These changes enhance the maintainability and readability of the codebase by ensuring consistent translation key usage across different components.