### PR TITLE
feat: call update_community_geodata in install script

### DIFF
--- a/src/backend/install.sh
+++ b/src/backend/install.sh
@@ -161,6 +161,8 @@ EOF
         printlog true "Logrotate configuration already exists. Skipping creation." $CWARN
     fi
 
+    update_community_geodata
+
     # ---------------------------------------------------------
     # performing version updates
 


### PR DESCRIPTION
This pull request includes a small change to the `src/backend/install.sh` file. The change adds a call to the `update_community_geodata` function to ensure community geodata is updated during the installation process.

* [`src/backend/install.sh`](diffhunk://#diff-a46228565461e80f30ec983b146342b33fcae1e373eb412b01bf3f32d91d2fb0R164-R165): Added a call to `update_community_geodata` to the installation script.