### PR TITLE
feat: validate profile name before adding to profiles list

### DIFF
--- a/src/components/Profiles.vue
+++ b/src/components/Profiles.vue
@@ -84,11 +84,15 @@
         }
       };
       const add = async () => {
+        if (profile_name.value === '') {
+          return;
+        }
         profile_name.value =
           profile_name.value
             .trim()
             .replace(/[^a-zA-Z0-9]/g, '_')
             .replace('.json', '') + '.json';
+
         if (profiles.value.indexOf(profile_name.value) === -1) {
           profiles.value.push(profile_name.value);
           modal.value.close();


### PR DESCRIPTION
This pull request includes a validation check in the `Profiles.vue` component to ensure that the profile name is not empty before proceeding with further processing.

Changes in `Profiles.vue`:

* Added a check to return early if `profile_name.value` is an empty string.