### PR TITLE
fix GitHub Proxy issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # XRAYUI Changelog
 
+## [0.42.4] - 2025-04-03
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- FIXED: unable to deselect `GitHub Proxy` option.
+- FIXED: Proxy the download link when updating the `XRAY-Core` from Github.
+
 ## [0.42.3] - 2025-04-03
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/backend/github.sh
+++ b/src/backend/github.sh
@@ -4,8 +4,9 @@
 github_proxy_url() {
     load_xrayui_config
     local github_url="$1"
-    local ghproxy="${github_proxy}"
-    if [ -z "$ghproxy" ]; then
+    local ghproxy="${github_proxy:-""}"
+
+    if [ ! -z "$ghproxy" ]; then
         github_url="${ghproxy}${github_url}"
     fi
     echo "$github_url"

--- a/src/backend/response.sh
+++ b/src/backend/response.sh
@@ -27,10 +27,8 @@ initial_response() {
     UI_RESPONSE=$(echo "$UI_RESPONSE" | jq --argjson uptime "$uptime_xray" '.xray.uptime = $uptime')
     UI_RESPONSE=$(echo "$UI_RESPONSE" | jq --arg profile "$profile" '.xray.profile = $profile')
 
-    local github_proxy="${github_proxy}"
-    if [ ! -z "$github_proxy" ]; then
-        UI_RESPONSE=$(echo "$UI_RESPONSE" | jq --arg github_proxy "$github_proxy" '.xray.github_proxy = $github_proxy')
-    fi
+    local github_proxy="${github_proxy:-""}"
+    UI_RESPONSE=$(echo "$UI_RESPONSE" | jq --arg github_proxy "$github_proxy" '.xray.github_proxy = $github_proxy')
 
     local XRAY_VERSION=$(xray version | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" | head -n 1)
     UI_RESPONSE=$(echo "$UI_RESPONSE" | jq --arg xray_ver "$XRAY_VERSION" --arg xrayui_ver "$XRAYUI_VERSION" '.xray.ui_version = $xrayui_ver | .xray.core_version = $xray_ver')

--- a/src/backend/update.sh
+++ b/src/backend/update.sh
@@ -4,7 +4,7 @@
 update() {
 
     update_loading_progress "Updating $ADDON_TITLE..." 0
-    local url="https://github.com/daniellavrushin/asuswrt-merlin-xrayui/releases/latest/download/asuswrt-merlin-xrayui.tar.gz"
+    local url=$(github_proxy_url "https://github.com/daniellavrushin/asuswrt-merlin-xrayui/releases/latest/download/asuswrt-merlin-xrayui.tar.gz")
     local temp_file="/tmp/asuswrt-merlin-xrayui.tar.gz"
     local jffs_addons_path="/jffs/addons"
 

--- a/src/backend/version.sh
+++ b/src/backend/version.sh
@@ -70,6 +70,9 @@ switch_xray_version() {
 
     local asset_url=$(echo "$release_data" |
         jq -r --arg NAME "$asset_name" '.[] | select(.name == $NAME) | .browser_download_url')
+    asset_url=$(github_proxy_url "$asset_url")
+
+    printlog true "Xray Core Asset URL: $asset_url" "$CSUC"
 
     if [ -z "$asset_url" ] || [ "$asset_url" = "null" ]; then
         printlog true "Error: could not find asset '$asset_name' in the release data" "$CERR"


### PR DESCRIPTION
This pull request includes several changes to improve the handling of GitHub proxy URLs and update the changelog. The most important changes include modifications to the `github_proxy_url` function, updates to various backend scripts to use this function, and updates to the changelog for the new version.

### Improvements to GitHub proxy URL handling:

* [`src/backend/github.sh`](diffhunk://#diff-eaf9e461a6db09b4efa20a683a83bc9c5320fa26a293d0d594a872e6b9009544L7-R9): Modified the `github_proxy_url` function to use a default empty string for the `ghproxy` variable and updated the condition to check if `ghproxy` is not empty.
* [`src/backend/response.sh`](diffhunk://#diff-7d11f2f9186a7d0b562bab541522489f1926982091dab525ad3defa133d415cfL30-L33): Simplified the handling of the `github_proxy` variable by using a default empty string and removed the unnecessary condition check.

### Updates to backend scripts:

* [`src/backend/update.sh`](diffhunk://#diff-6cdeaf26e7fa48121a539cfd1da6ca94763485fc6ab75bb23d99837068393162L7-R7): Updated the `update` function to use the `github_proxy_url` function for constructing the download URL.
* [`src/backend/version.sh`](diffhunk://#diff-14501970986a67559907a4f6b2f10eb13838239ce77af4fe7b72866181185dceR73-R75): Updated the `switch_xray_version` function to use the `github_proxy_url` function for constructing the asset URL and added a log statement to print the asset URL.

### Changelog update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R9): Added a new entry for version 0.42.4, including fixes for deselecting the `GitHub Proxy` option and proxying the download link when updating the `XRAY-Core` from GitHub.