### PR TITLE
fix: remove redundant cleanup of ADDON_WEB_DIR in unmount_ui function

### DIFF
--- a/src/backend/mount.sh
+++ b/src/backend/mount.sh
@@ -88,8 +88,6 @@ unmount_ui() {
         mount -o bind /tmp/menuTree.js /www/require/modules/menuTree.js
     fi
 
-    rm -rf $ADDON_WEB_DIR
-
     rm -rf "/opt/bin/$ADDON_TAG" || printlog true "Failed to remove symlink for $ADDON_TAG." $CERR
 
     clear_lock


### PR DESCRIPTION
This pull request includes a small but crucial change to the `unmount_ui` function in the `src/backend/mount.sh` file. The change removes the line that deletes the `$ADDON_WEB_DIR` directory, which could prevent potential issues related to the directory's removal.

* [`src/backend/mount.sh`](diffhunk://#diff-dbe16723d8aaf0995d92c9fa651e4343a2a63a79e6860e656efdfe93da0082c2L91-L92): Removed the line `rm -rf $ADDON_WEB_DIR` from the `unmount_ui` function to avoid unintended deletion of the directory.