### PR TITLE
Refactor and enhance code structure across multiple components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # XRAYUI Changelog
 
+## [0.42.8] - 2025-04-08
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- ADDED: Support added for configuring multiple `DOKODEMO` inbounds.
+- ADDED: Inbound `DOKODEMO` proxies can now be split by processing method—either Direct (`REDIRECT`) or `TPROXY`, and by network protocol (`TCP`, `UDP`, or `both`).
+- IMPROVED: Disable log fetching during configuration updates to prevent unexpected page reloads.
+
 ## [0.42.7] - 2025-04-06
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/App.vue
+++ b/src/App.vue
@@ -14,9 +14,6 @@
 
   import engine, { EngineResponseConfig, SubmtActions } from './modules/Engine';
 
-  // Helper delay function
-  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
   export default defineComponent({
     name: 'App',
     components: {
@@ -41,7 +38,7 @@
           await engine.loadXrayConfig();
           await engine.submit(SubmtActions.initResponse);
           // Use our delay helper instead of setTimeout inside an async function.
-          await delay(1000);
+          await engine.delay(1000);
           uiResponse.value = await engine.getXrayResponse();
         } catch (error) {
           console.error('Error during initialization:', error);

--- a/src/components/Logs.vue
+++ b/src/components/Logs.vue
@@ -58,7 +58,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, onMounted, onBeforeUnmount, ref, computed, watch } from 'vue';
+  import { defineComponent, onMounted, onBeforeUnmount, ref, computed } from 'vue';
   import axios from 'axios';
   import engine, { SubmtActions } from '@/modules/Engine';
   import { XrayLogObject } from '@/modules/CommonObjects';
@@ -113,12 +113,10 @@
       const file = ref<string>(FILE_ACCESS);
       const logsContent = ref<string>('');
 
-      // Wrap device mapping in a computed property.
       const devices = computed(() => {
         return Object.fromEntries(Object.entries(window.xray.router.devices_online).map(([mac, device]) => [device.ip, device]));
       });
 
-      // Use a computed property to parse logs on the fly.
       const parsedLogs = computed<AccessLogEntry[]>(() => {
         if (!logsContent.value) return [];
         return logsContent.value
@@ -132,12 +130,10 @@
           .filter((entry): entry is AccessLogEntry => entry !== null);
       });
 
-      // Refactored fetchLogs with a proper delay and error handling.
       const fetchLogs = async () => {
         if (!follow.value) return;
         try {
           await engine.submit(SubmtActions.fetchXrayLogs);
-          // Wait for 1 second before fetching the updated logs.
           await new Promise((resolve) => setTimeout(resolve, 1000));
           const response = await axios.get(file.value);
           logsContent.value = response.data;
@@ -148,7 +144,6 @@
 
       let refreshInterval: number;
       onMounted(() => {
-        // Start auto-refresh; the interval will run regardless, but fetchLogs itself returns early if follow is false.
         refreshInterval = window.setInterval(fetchLogs, 2000);
       });
 

--- a/src/components/MainForm.vue
+++ b/src/components/MainForm.vue
@@ -44,7 +44,7 @@
                                 <input class="button_gen" @click.prevent="apply_settings()" type="button" :value="$t('labels.apply')" />
                               </div>
                               <clients-online></clients-online>
-                              <logs-manager v-if="config.log?.access != 'none' || config.log?.error != 'none'" v-model:logs="config.log!"></logs-manager>
+                              <logs-manager ref="logsManager" v-if="config.log?.access != 'none' || config.log?.error != 'none'" v-model:logs="config.log!"></logs-manager>
                               <version></version>
                             </div>
                           </td>
@@ -112,6 +112,7 @@
       const config = ref(engine.xrayConfig);
       const transportModal = ref();
       const sniffingModal = ref();
+      const logsManager = ref();
 
       const show_transport = (proxy: XrayInboundObject<IProtocolType> | XrayOutboundObject<IProtocolType>, type: string) => {
         transportModal.value.show(proxy, type);
@@ -124,12 +125,17 @@
       const apply_settings = async () => {
         await engine.executeWithLoadingProgress(async () => {
           let cfg = engine.prepareServerConfig(config.value);
+          if (logsManager.value && logsManager.value.follow) {
+            logsManager.value.follow = false;
+            await engine.delay(1000);
+          }
           await engine.submit(SubmtActions.configurationApply, cfg);
           await engine.loadXrayConfig();
         });
       };
 
       return {
+        logsManager,
         config,
         engine,
         transportModal,

--- a/src/components/ServiceStatus.vue
+++ b/src/components/ServiceStatus.vue
@@ -49,7 +49,7 @@
   import GeneralOptionsModal from '@modal/GeneralOptionsModal.vue';
   import ImportConfig from './ImportConfig.vue';
   import { XrayObject } from '@/modules/XrayConfig';
-  import { XrayProtocol, XrayRoutingRuleObject } from '@/modules/CommonObjects';
+  import { XrayRoutingRuleObject } from '@/modules/CommonObjects';
   import ConfigModal from '@modal/ConfigModal.vue';
   import axios from 'axios';
   import { useI18n } from 'vue-i18n';
@@ -57,6 +57,7 @@
   import XrayVersion from './XrayVersion.vue';
   import Profiles from './Profiles.vue';
   import Backup from './Backup.vue';
+  import { XrayProtocol } from '@/modules/Options';
 
   class IpApiResponse {
     public status?: string;

--- a/src/components/modals/GeneralOptionsModal.vue
+++ b/src/components/modals/GeneralOptionsModal.vue
@@ -126,10 +126,11 @@
   import { defineComponent, inject, Ref, ref, watch } from 'vue';
   import engine, { EngineResponseConfig, SubmtActions } from '@/modules/Engine';
   import { XrayObject } from '@/modules/XrayConfig';
-  import { XrayProtocol, XrayRoutingRuleObject } from '@/modules/CommonObjects';
+  import { XrayRoutingRuleObject } from '@/modules/CommonObjects';
   import Hint from '@main/Hint.vue';
   import Modal from '@main/Modal.vue';
   import { XrayInboundObject, XraySocksInboundObject } from '@/modules/InboundObjects';
+  import { XrayProtocol } from '@/modules/Options';
 
   class GeneralOptions {
     public startup = false;

--- a/src/components/modals/ImportConfigModal.vue
+++ b/src/components/modals/ImportConfigModal.vue
@@ -73,9 +73,10 @@
   import { XrayObject } from '@/modules/XrayConfig';
   import ProxyParser from '@/modules/parsers/ProxyParser';
   import Hint from '@main/Hint.vue';
-  import { XrayDnsObject, XrayLogObject, XrayRoutingPolicy, XrayProtocol, XrayRoutingObject, XraySniffingObject } from '@/modules/CommonObjects';
+  import { XrayDnsObject, XrayLogObject, XrayRoutingPolicy, XrayRoutingObject, XraySniffingObject } from '@/modules/CommonObjects';
   import { XrayDokodemoDoorInboundObject, XrayInboundObject } from '@/modules/InboundObjects';
   import { XrayBlackholeOutboundObject, XrayFreedomOutboundObject, XrayOutboundObject } from '@/modules/OutboundObjects';
+  import { XrayProtocol } from '@/modules/Options';
 
   export default defineComponent({
     name: 'ImportConfigModal',

--- a/src/modules/ClientsObjects.ts
+++ b/src/modules/ClientsObjects.ts
@@ -1,20 +1,20 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 import { IClient } from './Interfaces';
 
-class XrayWireguardClientObject implements IClient {
+export class XrayWireguardClientObject implements IClient {
   public publicKey!: string;
   public allowedIPs: string[] = [];
 
   normalize = () => void 0;
 }
 
-class XraySocksClientObject implements IClient {
+export class XraySocksClientObject implements IClient {
   public pass!: string;
   public user!: string;
   normalize = () => void 0;
 }
 
-class XrayShadowsocksClientObject implements IClient {
+export class XrayShadowsocksClientObject implements IClient {
   public email!: string;
   public password!: string;
   public level?: number;
@@ -22,7 +22,7 @@ class XrayShadowsocksClientObject implements IClient {
   normalize = () => void 0;
 }
 
-class XrayVmessClientObject implements IClient {
+export class XrayVmessClientObject implements IClient {
   public id!: string;
   public email!: string;
   public level?: number;
@@ -30,19 +30,19 @@ class XrayVmessClientObject implements IClient {
   normalize = () => void 0;
 }
 
-class XrayHttpClientObject implements IClient {
+export class XrayHttpClientObject implements IClient {
   public pass!: string;
   public user!: string;
   normalize = () => void 0;
 }
 
-class XrayTrojanClientObject implements IClient {
+export class XrayTrojanClientObject implements IClient {
   public password!: string;
   public email!: string;
   normalize = () => void 0;
 }
 
-class XrayVlessClientObject implements IClient {
+export class XrayVlessClientObject implements IClient {
   public id!: string;
   public email!: string;
   public level?: number;
@@ -50,5 +50,3 @@ class XrayVlessClientObject implements IClient {
   public flow? = 'none';
   normalize = () => void 0;
 }
-
-export { XrayWireguardClientObject, XraySocksClientObject, XrayShadowsocksClientObject, XrayVmessClientObject, XrayHttpClientObject, XrayTrojanClientObject, XrayVlessClientObject };

--- a/src/modules/CommonObjects.ts
+++ b/src/modules/CommonObjects.ts
@@ -3,7 +3,7 @@ import { ISecurityProtocol, IXrayServer } from './Interfaces';
 import XrayOptions, { XrayProtocol, XrayProtocolMode } from './Options';
 import { XrayStreamHttpSettingsObject, XrayStreamKcpSettingsObject, XrayStreamTcpSettingsObject, XrayStreamWsSettingsObject, XrayStreamGrpcSettingsObject, XrayStreamHttpUpgradeSettingsObject, XrayStreamSplitHttpSettingsObject } from './TransportObjects';
 
-class XraySniffingObject {
+export class XraySniffingObject {
   static destOverrideOptions = ['http', 'tls', 'quic', 'fakedns'];
   public enabled? = false;
   public metadataOnly? = false;
@@ -20,34 +20,34 @@ class XraySniffingObject {
   }
 }
 
-class XrayHeaderObject {
+export class XrayHeaderObject {
   public type = 'none';
   public request?: XrayHeaderRequestObject;
   public response?: XrayHeaderResponseObject;
 }
 
-class XrayHeaderRequestObject {
+export class XrayHeaderRequestObject {
   public version = '1.1';
   public method = 'GET';
   public path = '/';
   public headers: unknown = {};
 }
 
-class XrayHeaderResponseObject {
+export class XrayHeaderResponseObject {
   public version = '1.1';
   public status = '200';
   public reason = 'OK';
   public headers: unknown = {};
 }
 
-class XrayXmuxObject {
+export class XrayXmuxObject {
   public maxConcurrency = 0;
   public maxConnections = 0;
   public cMaxReuseTimes = 0;
   public cMaxLifetimeMs = 0;
 }
 
-class XrayAllocateObject {
+export class XrayAllocateObject {
   static defaultRefresh = 5;
   static defaultConcurrency = 3;
 
@@ -64,7 +64,7 @@ class XrayAllocateObject {
   };
 }
 
-class XrayStreamTlsCertificateObject {
+export class XrayStreamTlsCertificateObject {
   static usageOptions = XrayOptions.usageOptions;
 
   public ocspStapling? = 3600;
@@ -85,7 +85,7 @@ class XrayStreamTlsCertificateObject {
   }
 }
 
-class XrayStreamTlsSettingsObject implements ISecurityProtocol {
+export class XrayStreamTlsSettingsObject implements ISecurityProtocol {
   static alpnOptions = XrayOptions.alpnOptions;
   static fingerprintOptions = ['', 'randomized', 'random', 'chrome', 'firefox', 'ios', 'android', 'safari', 'edge', '360', 'qq'];
   static tlsVersionsOptions = ['1.0', '1.1', '1.2', '1.3'];
@@ -135,7 +135,7 @@ class XrayStreamTlsSettingsObject implements ISecurityProtocol {
   }
 }
 
-class XrayStreamRealitySettingsObject implements ISecurityProtocol {
+export class XrayStreamRealitySettingsObject implements ISecurityProtocol {
   public show = false;
   public dest?: string;
   public xver?: number;
@@ -167,7 +167,7 @@ class XrayStreamRealitySettingsObject implements ISecurityProtocol {
   }
 }
 
-class XrayLogObject {
+export class XrayLogObject {
   static levelOptions = ['debug', 'info', 'warning', 'error', 'none'];
   public access?: string;
   public error?: string;
@@ -186,7 +186,7 @@ class XrayLogObject {
   }
 }
 
-class XrayDnsObject {
+export class XrayDnsObject {
   static strategyOptions = ['UseIP', 'UseIPv4', 'UseIPv6'];
   public tag? = 'dnsQuery';
   public hosts?: Record<string, string | string[]> | undefined = {};
@@ -215,7 +215,7 @@ class XrayDnsObject {
   };
 }
 
-class XrayDnsServerObject {
+export class XrayDnsServerObject {
   public address!: string;
   public port?: number;
   public domains?: string[];
@@ -223,16 +223,17 @@ class XrayDnsServerObject {
   public skipFallback?: boolean;
   public clientIP?: string;
 }
-const XrayReverseItemType = {
+export const XrayReverseItemType = {
   BRIDGE: 'bridge',
   PORTAL: 'portal'
 };
-class XrayReverseItem {
+
+export class XrayReverseItem {
   public tag?: string;
   public domain?: string;
 }
 
-class XrayReverseObject {
+export class XrayReverseObject {
   public bridges?: XrayReverseItem[] = [];
   public portals?: XrayReverseItem[] = [];
 
@@ -255,7 +256,7 @@ class XrayReverseObject {
   }
 }
 
-class XrayRoutingObject {
+export class XrayRoutingObject {
   static domainStrategyOptions = ['AsIs', 'IPIfNonMatch', 'IPOnDemand'];
   static domainMatcherOptions = ['hybrid', 'linear'];
   public domainStrategy? = 'AsIs';
@@ -343,7 +344,7 @@ class XrayRoutingObject {
   };
 }
 
-class XrayRoutingPolicy {
+export class XrayRoutingPolicy {
   static defaultPorts = ['443', '80', '22'];
   static modes = ['redirect', 'bypass'];
   public name?: string;
@@ -393,7 +394,7 @@ class XrayRoutingPolicy {
   };
 }
 
-class XrayRoutingRuleObject {
+export class XrayRoutingRuleObject {
   static connectionCheckRuleName = 'sys:connection-check';
   static networkOptions = ['', 'tcp', 'udp', 'tcp,udp'];
   static protocolOptions = ['http', 'tls', 'bittorrent'];
@@ -435,7 +436,7 @@ class XrayRoutingRuleObject {
   };
 }
 
-class XrayStreamSettingsObject {
+export class XrayStreamSettingsObject {
   public network? = 'tcp';
   public security? = 'none';
   public tlsSettings?: XrayStreamTlsSettingsObject;
@@ -470,13 +471,13 @@ class XrayStreamSettingsObject {
   }
 }
 
-class XrayServerObject<IClient> implements IXrayServer<IClient> {
+export class XrayServerObject<IClient> implements IXrayServer<IClient> {
   public address!: string;
   public port!: number;
   public users?: IClient[] | undefined = [];
 }
 
-class XrayTrojanServerObject extends XrayServerObject<XrayHttpClientObject> {
+export class XrayTrojanServerObject extends XrayServerObject<XrayHttpClientObject> {
   public email?: string;
   public password!: string;
   public level? = 0;
@@ -486,11 +487,11 @@ class XrayTrojanServerObject extends XrayServerObject<XrayHttpClientObject> {
   }
 }
 
-class XrayHttpServerObject extends XrayServerObject<XrayHttpClientObject> {}
-class XraySocksServerObject extends XrayServerObject<XraySocksClientObject> {}
-class XrayVlessServerObject extends XrayServerObject<XrayVlessClientObject> {}
-class XrayVmessServerObject extends XrayServerObject<XrayVmessClientObject> {}
-class XrayShadowsocksServerObject extends XrayServerObject<XrayVmessClientObject> {
+export class XrayHttpServerObject extends XrayServerObject<XrayHttpClientObject> {}
+export class XraySocksServerObject extends XrayServerObject<XraySocksClientObject> {}
+export class XrayVlessServerObject extends XrayServerObject<XrayVlessClientObject> {}
+export class XrayVmessServerObject extends XrayServerObject<XrayVmessClientObject> {}
+export class XrayShadowsocksServerObject extends XrayServerObject<XrayVmessClientObject> {
   public email?: string;
   public method = '2022-blake3-aes-256-gcm';
   public password!: string;
@@ -502,19 +503,19 @@ class XrayShadowsocksServerObject extends XrayServerObject<XrayVmessClientObject
   }
 }
 
-class XrayProtocolOption {
+export class XrayProtocolOption {
   public protocol!: string;
   public modes!: XrayProtocolMode;
 }
 
-class XrayNoiseObject {
+export class XrayNoiseObject {
   static typeOptions = ['rand', 'str', 'base64'];
   public type = 'rand';
   public packet!: string;
   public delay: string | number = 0;
 }
 
-class XrayPeerObject {
+export class XrayPeerObject {
   public endpoint!: string;
   public publicKey!: string;
   public preSharedKey?: string;
@@ -522,7 +523,7 @@ class XrayPeerObject {
   public keepAlive?: number;
 }
 
-class XraySockoptObject {
+export class XraySockoptObject {
   static tproxyOptions = ['off', 'redirect', 'tproxy'];
   static domainStrategyOptions = ['AsIs', 'UseIP', 'UseIPv4', 'UseIPv6'];
 
@@ -550,7 +551,8 @@ class XraySockoptObject {
     return this;
   };
 }
-interface ParseJsonObject {
+
+export interface ParseJsonObject {
   add: string;
   id: string;
   ps: string;
@@ -560,7 +562,7 @@ interface ParseJsonObject {
   [key: string]: string;
 }
 
-class XrayParsedUrlObject {
+export class XrayParsedUrlObject {
   public server!: string;
   public port!: number;
   public protocol!: string;
@@ -619,4 +621,4 @@ class XrayParsedUrlObject {
   }
 }
 
-export { XrayReverseItemType, XrayReverseObject, XrayReverseItem, XrayRoutingPolicy, XrayParsedUrlObject, XraySockoptObject, XrayDnsObject, XrayDnsServerObject, XrayTrojanServerObject, XrayPeerObject, XrayNoiseObject, XrayShadowsocksServerObject, XrayHttpServerObject, XraySocksServerObject, XrayProtocolOption, XrayProtocol, XrayVlessServerObject, XrayVmessServerObject, XrayStreamTlsSettingsObject, XrayStreamRealitySettingsObject, XrayStreamTlsCertificateObject, XrayStreamSettingsObject, XrayRoutingRuleObject, XrayRoutingObject, XrayLogObject, XrayAllocateObject, XraySniffingObject, XrayHeaderObject, XrayHeaderRequestObject, XrayHeaderResponseObject, XrayXmuxObject };
+export { XrayProtocol };

--- a/src/modules/Engine.ts
+++ b/src/modules/Engine.ts
@@ -9,10 +9,11 @@
 import axios, { AxiosError } from 'axios';
 import { xrayConfig, XrayObject } from './XrayConfig';
 import { XrayBlackholeOutboundObject, XrayLoopbackOutboundObject, XrayDnsOutboundObject, XrayFreedomOutboundObject, XrayTrojanOutboundObject, XrayOutboundObject, XraySocksOutboundObject, XrayVmessOutboundObject, XrayVlessOutboundObject, XrayHttpOutboundObject, XrayShadowsocksOutboundObject } from './OutboundObjects';
-import { XrayProtocol, XrayDnsObject, XrayStreamSettingsObject, XrayRoutingObject, XrayRoutingRuleObject, XraySniffingObject, XrayRoutingPolicy, XrayAllocateObject, XrayStreamRealitySettingsObject, XrayStreamTlsSettingsObject, XraySockoptObject, XrayLogObject, XrayStreamTlsCertificateObject, XrayReverseObject, XrayReverseItem } from './CommonObjects';
+import { XrayDnsObject, XrayStreamSettingsObject, XrayRoutingObject, XrayRoutingRuleObject, XraySniffingObject, XrayRoutingPolicy, XrayAllocateObject, XrayStreamRealitySettingsObject, XrayStreamTlsSettingsObject, XraySockoptObject, XrayLogObject, XrayStreamTlsCertificateObject, XrayReverseObject, XrayReverseItem } from './CommonObjects';
 import { plainToInstance } from 'class-transformer';
 import { XrayDokodemoDoorInboundObject, XrayHttpInboundObject, XrayInboundObject, XrayShadowsocksInboundObject, XraySocksInboundObject, XrayTrojanInboundObject, XrayVlessInboundObject, XrayVmessInboundObject, XrayWireguardInboundObject } from './InboundObjects';
 import { XrayStreamHttpSettingsObject, XrayStreamGrpcSettingsObject, XrayStreamHttpUpgradeSettingsObject, XrayStreamKcpSettingsObject, XrayStreamTcpSettingsObject, XrayStreamWsSettingsObject } from './TransportObjects';
+import { XrayProtocol } from './Options';
 
 class EngineWireguard {
   public privateKey!: string;
@@ -119,6 +120,7 @@ class Engine {
     }
     return chunks;
   }
+  public delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
   public setCookie = (name: string, val: string): void => {
     const date = new Date();

--- a/src/modules/InboundObjects.ts
+++ b/src/modules/InboundObjects.ts
@@ -4,7 +4,7 @@ import { XrayAllocateObject, XraySniffingObject, XrayStreamSettingsObject } from
 import { XrayVlessClientObject, XrayVmessClientObject, XrayHttpClientObject, XrayShadowsocksClientObject, XrayTrojanClientObject, XraySocksClientObject, XrayWireguardClientObject } from './ClientsObjects';
 import { plainToInstance } from 'class-transformer';
 
-class XrayInboundObject<TProxy extends IProtocolType> {
+export class XrayInboundObject<TProxy extends IProtocolType> {
   public protocol!: string;
   public listen? = '0.0.0.0';
   public port!: number | string;
@@ -46,7 +46,7 @@ class XrayInboundObject<TProxy extends IProtocolType> {
   };
 }
 
-class XrayDokodemoDoorInboundObject implements IProtocolType {
+export class XrayDokodemoDoorInboundObject implements IProtocolType {
   public address?: string;
   public port?: number;
   public network?: string = 'tcp';
@@ -59,7 +59,7 @@ class XrayDokodemoDoorInboundObject implements IProtocolType {
     this.port = this.port && this.port > 0 ? this.port : undefined;
   };
 }
-class XrayVlessInboundObject implements IProtocolType {
+export class XrayVlessInboundObject implements IProtocolType {
   public decryption = 'none';
   public clients: XrayVlessClientObject[] = [];
   normalize = () => void 0;
@@ -68,7 +68,7 @@ class XrayVlessInboundObject implements IProtocolType {
   };
 }
 
-class XrayVmessInboundObject implements IProtocolType {
+export class XrayVmessInboundObject implements IProtocolType {
   public clients: XrayVmessClientObject[] = [];
   normalize = () => void 0;
   getUserNames = (): string[] => {
@@ -76,7 +76,7 @@ class XrayVmessInboundObject implements IProtocolType {
   };
 }
 
-class XrayHttpInboundObject implements IProtocolType {
+export class XrayHttpInboundObject implements IProtocolType {
   public allowTransparent? = false;
   public clients: XrayHttpClientObject[] = [];
   normalize = () => {
@@ -88,7 +88,7 @@ class XrayHttpInboundObject implements IProtocolType {
   };
 }
 
-class XrayShadowsocksInboundObject implements IProtocolType {
+export class XrayShadowsocksInboundObject implements IProtocolType {
   public network? = 'tcp';
   public clients: XrayShadowsocksClientObject[] = [];
   normalize = () => {
@@ -99,7 +99,7 @@ class XrayShadowsocksInboundObject implements IProtocolType {
   };
 }
 
-class XrayTrojanInboundObject implements IProtocolType {
+export class XrayTrojanInboundObject implements IProtocolType {
   public clients: XrayTrojanClientObject[] = [];
   normalize = () => void 0;
   getUserNames = (): string[] => {
@@ -107,7 +107,7 @@ class XrayTrojanInboundObject implements IProtocolType {
   };
 }
 
-class XraySocksInboundObject implements IProtocolType {
+export class XraySocksInboundObject implements IProtocolType {
   public ip? = '127.0.0.1';
   public auth? = 'noauth';
   public accounts?: XraySocksClientObject[] = [];
@@ -123,12 +123,10 @@ class XraySocksInboundObject implements IProtocolType {
   };
 }
 
-class XrayWireguardInboundObject implements IProtocolType {
+export class XrayWireguardInboundObject implements IProtocolType {
   public secretKey!: string;
   public kernelMode = true;
   public mtu = 1420;
   public peers: XrayWireguardClientObject[] = [];
   normalize = () => void 0;
 }
-
-export { XrayInboundObject, XrayWireguardInboundObject, XraySocksInboundObject, XrayTrojanInboundObject, XrayShadowsocksInboundObject, XrayHttpInboundObject, XrayVmessInboundObject, XrayVlessInboundObject, XrayDokodemoDoorInboundObject };

--- a/src/modules/Interfaces.ts
+++ b/src/modules/Interfaces.ts
@@ -1,29 +1,27 @@
-interface IProtocolType {
+export interface IProtocolType {
   normalize?: () => void;
   //eslint-disable-next-line
   isTargetAddress?: (address: string) => boolean;
   getUserNames?: () => string[];
 }
 
-interface ITransportNetwork {
+export interface ITransportNetwork {
   normalize?: () => void;
 }
-interface ISecurityProtocol {
-  normalize?: () => void;
-}
-
-interface IClient {
+export interface ISecurityProtocol {
   normalize?: () => void;
 }
 
-interface IXrayServer<TClient> {
+export interface IClient {
+  normalize?: () => void;
+}
+
+export interface IXrayServer<TClient> {
   users?: TClient[] | undefined;
 }
 
-interface XrayRouterDeviceOnline {
+export interface XrayRouterDeviceOnline {
   name: string;
   ip: string;
   mac: string;
 }
-
-export { IXrayServer, XrayRouterDeviceOnline, ISecurityProtocol, IProtocolType, ITransportNetwork, IClient };

--- a/src/modules/Options.ts
+++ b/src/modules/Options.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/prefer-literal-enum-member */
-const XrayOptions = {
+export const XrayOptions = {
   transportOptions: ['tcp', 'kcp', 'ws', 'xhttp', 'grpc', 'httpupgrade', 'splithttp'],
   securityOptions: ['none', 'tls', 'reality'],
   logOptions: ['debug', 'info', 'warning', 'error', 'none'],
@@ -18,7 +18,7 @@ const XrayOptions = {
   encryptionOptions: ['none', 'plain', 'aes-128-gcm', 'aes-256-gcm', 'chacha20-ietf-poly1305', '2022-blake3-aes-128-gcm', '2022-blake3-aes-256-gcm', '2022-blake3-chacha20-poly1305']
 };
 
-const XrayProtocol = {
+export const XrayProtocol = {
   VLESS: 'vless',
   VMESS: 'vmess',
   SHADOWSOCKS: 'shadowsocks',
@@ -32,7 +32,7 @@ const XrayProtocol = {
   BLACKHOLE: 'blackhole',
   LOOPBACK: 'loopback'
 };
-enum XrayProtocolMode {
+export enum XrayProtocolMode {
   Inbound = 1 << 0,
   Outbound = 1 << 1,
   ServerMode = 1 << 2,
@@ -43,4 +43,3 @@ enum XrayProtocolMode {
 }
 
 export default XrayOptions;
-export { XrayOptions, XrayProtocol, XrayProtocolMode };

--- a/src/modules/OutboundObjects.ts
+++ b/src/modules/OutboundObjects.ts
@@ -6,7 +6,7 @@ import { XrayTrojanServerObject, XrayHttpServerObject, XrayStreamSettingsObject,
 import { XrayVlessServerObject } from './CommonObjects';
 import { plainToInstance } from 'class-transformer';
 
-class XrayOutboundObject<TProxy extends IProtocolType> {
+export class XrayOutboundObject<TProxy extends IProtocolType> {
   public protocol!: string;
   public sendThrough? = '0.0.0.0';
   public tag?: string;
@@ -36,7 +36,7 @@ class XrayOutboundObject<TProxy extends IProtocolType> {
   };
 }
 
-class XrayVlessOutboundObject implements IProtocolType {
+export class XrayVlessOutboundObject implements IProtocolType {
   public vnext: XrayVlessServerObject[] = [];
   constructor() {
     if (this.vnext.length === 0) this.vnext.push(new XrayVlessServerObject());
@@ -51,7 +51,7 @@ class XrayVlessOutboundObject implements IProtocolType {
   };
 }
 
-class XrayVmessOutboundObject implements IProtocolType {
+export class XrayVmessOutboundObject implements IProtocolType {
   public vnext: XrayVmessServerObject[] = [];
   constructor() {
     if (this.vnext.length === 0) this.vnext.push(new XrayVmessServerObject());
@@ -66,14 +66,14 @@ class XrayVmessOutboundObject implements IProtocolType {
   };
 }
 
-class XrayBlackholeOutboundObject implements IProtocolType {
+export class XrayBlackholeOutboundObject implements IProtocolType {
   public response?: { type: string } = { type: 'none' }; // none, http
   normalize = () => {
     this.response = this.response?.type === 'none' ? undefined : this.response;
   };
 }
 
-class XrayHttpOutboundObject implements IProtocolType {
+export class XrayHttpOutboundObject implements IProtocolType {
   public servers: XrayHttpServerObject[] = [];
   constructor() {
     if (this.servers.length === 0) this.servers.push(new XrayHttpServerObject());
@@ -87,7 +87,7 @@ class XrayHttpOutboundObject implements IProtocolType {
     return this.servers.flatMap((c) => c.users?.map((u) => u.user).filter((email): email is string => !!email) ?? []);
   };
 }
-class XrayShadowsocksOutboundObject implements IProtocolType {
+export class XrayShadowsocksOutboundObject implements IProtocolType {
   public servers: XrayShadowsocksServerObject[] = [];
   constructor() {
     if (this.servers.length === 0) this.servers.push(new XrayShadowsocksServerObject());
@@ -99,7 +99,7 @@ class XrayShadowsocksOutboundObject implements IProtocolType {
   };
 }
 
-class XrayTrojanOutboundObject implements IProtocolType {
+export class XrayTrojanOutboundObject implements IProtocolType {
   public servers: XrayTrojanServerObject[] = [];
   constructor() {
     if (this.servers.length === 0) this.servers.push(new XrayTrojanServerObject());
@@ -114,7 +114,7 @@ class XrayTrojanOutboundObject implements IProtocolType {
   };
 }
 
-class XrayWireguardOutboundObject implements IProtocolType {
+export class XrayWireguardOutboundObject implements IProtocolType {
   static strategyOptions = ['ForceIPv6v4', 'ForceIPv6', 'ForceIPv4v6', 'ForceIPv4', 'ForceIP'];
   public privateKey!: string;
   public address: string[] = [];
@@ -128,12 +128,12 @@ class XrayWireguardOutboundObject implements IProtocolType {
   normalize = () => void 0;
 }
 
-class XrayLoopbackOutboundObject implements IProtocolType {
+export class XrayLoopbackOutboundObject implements IProtocolType {
   public inboundTag!: string;
 
   normalize = () => void 0;
 }
-class XrayFreedomOutboundObject implements IProtocolType {
+export class XrayFreedomOutboundObject implements IProtocolType {
   static strategyOptions = ['AsIs', 'UseIP', 'UseIPv4', 'UseIPv6'];
   static fragmentOptions = ['1-3', 'tlshello'];
   public domainStrategy? = 'AsIs';
@@ -151,7 +151,7 @@ class XrayFreedomOutboundObject implements IProtocolType {
   };
 }
 
-class XrayDnsOutboundObject implements IProtocolType {
+export class XrayDnsOutboundObject implements IProtocolType {
   public address?: string;
   public port?: number;
   public network?: string = 'tcp';
@@ -165,7 +165,7 @@ class XrayDnsOutboundObject implements IProtocolType {
   };
 }
 
-class XraySocksOutboundObject implements IProtocolType {
+export class XraySocksOutboundObject implements IProtocolType {
   public servers: XraySocksServerObject[] = [];
   constructor() {
     if (this.servers.length === 0) this.servers.push(new XraySocksServerObject());
@@ -179,5 +179,3 @@ class XraySocksOutboundObject implements IProtocolType {
     return this.servers.flatMap((c) => c.users?.map((u) => u.user).filter((email): email is string => !!email) ?? []);
   };
 }
-
-export { XrayWireguardOutboundObject, XrayTrojanOutboundObject, XraySocksOutboundObject, XrayShadowsocksOutboundObject, XrayDnsOutboundObject, XrayFreedomOutboundObject, XrayLoopbackOutboundObject, XrayBlackholeOutboundObject, XrayHttpOutboundObject, XrayVlessOutboundObject, XrayVmessOutboundObject, XrayOutboundObject };

--- a/src/modules/TransportObjects.ts
+++ b/src/modules/TransportObjects.ts
@@ -1,14 +1,14 @@
 import { XrayHeaderObject, XrayParsedUrlObject, XrayXmuxObject } from './CommonObjects';
 import { ITransportNetwork } from './Interfaces';
 
-class XrayStreamTcpSettingsObject implements ITransportNetwork {
+export class XrayStreamTcpSettingsObject implements ITransportNetwork {
   public acceptProxyProtocol? = false;
   normalize = () => {
     this.acceptProxyProtocol = !this.acceptProxyProtocol ? undefined : this.acceptProxyProtocol;
   };
 }
 
-class XrayStreamKcpSettingsObject implements ITransportNetwork {
+export class XrayStreamKcpSettingsObject implements ITransportNetwork {
   static headerTypes = ['none', 'srtp', 'utp', 'wechat-video', 'dtls', 'wireguard'];
 
   public mtu? = 1350;
@@ -44,7 +44,7 @@ class XrayStreamKcpSettingsObject implements ITransportNetwork {
   };
 }
 
-class XrayStreamWsSettingsObject implements ITransportNetwork {
+export class XrayStreamWsSettingsObject implements ITransportNetwork {
   public acceptProxyProtocol = false;
   public path = '/';
   public host?: string;
@@ -59,7 +59,7 @@ class XrayStreamWsSettingsObject implements ITransportNetwork {
   normalize = () => void 0;
 }
 
-class XrayStreamHttpSettingsObject implements ITransportNetwork {
+export class XrayStreamHttpSettingsObject implements ITransportNetwork {
   public host?: string[];
   public path = '/';
   public headers = {};
@@ -69,7 +69,7 @@ class XrayStreamHttpSettingsObject implements ITransportNetwork {
   normalize = () => void 0;
 }
 
-class XrayStreamGrpcSettingsObject implements ITransportNetwork {
+export class XrayStreamGrpcSettingsObject implements ITransportNetwork {
   public serviceName = '';
   public multiMode = false;
   public idle_timeout = 60;
@@ -79,7 +79,7 @@ class XrayStreamGrpcSettingsObject implements ITransportNetwork {
   normalize = () => void 0;
 }
 
-class XrayStreamHttpUpgradeSettingsObject implements ITransportNetwork {
+export class XrayStreamHttpUpgradeSettingsObject implements ITransportNetwork {
   public acceptProxyProtocol = false;
   public path = '/';
   public host?: string;
@@ -87,7 +87,7 @@ class XrayStreamHttpUpgradeSettingsObject implements ITransportNetwork {
   normalize = () => void 0;
 }
 
-class XrayStreamSplitHttpSettingsObject implements ITransportNetwork {
+export class XrayStreamSplitHttpSettingsObject implements ITransportNetwork {
   public path = '/';
   public host?: string;
   public headers = {};
@@ -98,5 +98,3 @@ class XrayStreamSplitHttpSettingsObject implements ITransportNetwork {
   public xmux: XrayXmuxObject = new XrayXmuxObject();
   normalize = () => void 0;
 }
-
-export { XrayStreamTcpSettingsObject, XrayStreamKcpSettingsObject, XrayStreamWsSettingsObject, XrayStreamHttpSettingsObject, XrayStreamSplitHttpSettingsObject, XrayStreamGrpcSettingsObject, XrayStreamHttpUpgradeSettingsObject };

--- a/src/modules/XrayConfig.ts
+++ b/src/modules/XrayConfig.ts
@@ -5,7 +5,7 @@ import { XrayInboundObject } from './InboundObjects';
 import { XrayOutboundObject } from './OutboundObjects';
 import { XrayProtocol, XrayProtocolMode } from './Options';
 
-class XrayObject {
+export class XrayObject {
   public log?: XrayLogObject = new XrayLogObject();
   public dns?: XrayDnsObject = new XrayDnsObject();
   public inbounds: XrayInboundObject<IProtocolType>[] = [];
@@ -14,7 +14,7 @@ class XrayObject {
   public reverse?: XrayReverseObject = new XrayReverseObject();
 }
 
-const xrayProtocols: XrayProtocolOption[] = [
+export const xrayProtocols: XrayProtocolOption[] = [
   {
     protocol: XrayProtocol.DOKODEMODOOR,
     modes: XrayProtocolMode.Inbound | XrayProtocolMode.BothModes
@@ -67,5 +67,4 @@ const xrayProtocols: XrayProtocolOption[] = [
 
 let xrayConfig = reactive(new XrayObject());
 export default xrayConfig;
-
-export { XrayObject, xrayConfig, xrayProtocols };
+export { xrayConfig };

--- a/src/modules/parsers/ShadowsocksParser.ts
+++ b/src/modules/parsers/ShadowsocksParser.ts
@@ -1,7 +1,8 @@
-import { XrayParsedUrlObject, XrayProtocol, XrayShadowsocksServerObject, XrayStreamSettingsObject } from '../CommonObjects';
+import { XrayParsedUrlObject, XrayShadowsocksServerObject, XrayStreamSettingsObject } from '../CommonObjects';
+import { XrayProtocol } from '../Options';
 import { XrayOutboundObject, XrayShadowsocksOutboundObject } from '../OutboundObjects';
 
-const ShadowsocksParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayShadowsocksOutboundObject> | null => {
+export default function ShadowsocksParser(parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayShadowsocksOutboundObject> | null {
   const proxy = new XrayOutboundObject<XrayShadowsocksOutboundObject>();
   proxy.tag = parsedObj.tag;
   proxy.settings = new XrayShadowsocksOutboundObject();
@@ -20,6 +21,4 @@ const ShadowsocksParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<X
   server.email = parsedObj.tag;
   proxy.settings.servers.push(server);
   return proxy;
-};
-
-export default ShadowsocksParser;
+}

--- a/src/modules/parsers/TrojanParser.ts
+++ b/src/modules/parsers/TrojanParser.ts
@@ -1,7 +1,8 @@
-import { XrayParsedUrlObject, XrayProtocol, XrayStreamSettingsObject, XrayTrojanServerObject } from '../CommonObjects';
+import { XrayParsedUrlObject, XrayStreamSettingsObject, XrayTrojanServerObject } from '../CommonObjects';
+import { XrayProtocol } from '../Options';
 import { XrayOutboundObject, XrayTrojanOutboundObject } from '../OutboundObjects';
 
-const TrojanParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayTrojanOutboundObject> | null => {
+export default function TrojanParser(parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayTrojanOutboundObject> | null {
   if (parsedObj.protocol !== XrayProtocol.TROJAN) return null;
   const proxy = new XrayOutboundObject<XrayTrojanOutboundObject>();
   proxy.tag = parsedObj.tag;
@@ -20,6 +21,4 @@ const TrojanParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayTr
   server.port = parsedObj.port;
   proxy.settings.servers.push(server);
   return proxy;
-};
-
-export default TrojanParser;
+}

--- a/src/modules/parsers/VlessParser.ts
+++ b/src/modules/parsers/VlessParser.ts
@@ -2,7 +2,7 @@ import { XrayVlessClientObject } from '../ClientsObjects';
 import { XrayParsedUrlObject, XrayStreamSettingsObject } from '../CommonObjects';
 import { XrayOutboundObject, XrayVlessOutboundObject } from '../OutboundObjects';
 
-const VlessParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVlessOutboundObject> | null => {
+export default function VlessParser(parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVlessOutboundObject> | null {
   if (parsedObj.protocol !== 'vless') return null;
   const proxy = new XrayOutboundObject<XrayVlessOutboundObject>();
   proxy.tag = parsedObj.tag;
@@ -25,6 +25,4 @@ const VlessParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVle
   if (proxy.settings.vnext[0].users) proxy.settings.vnext[0].users.push(user);
 
   return proxy;
-};
-
-export default VlessParser;
+}

--- a/src/modules/parsers/VmessParser.ts
+++ b/src/modules/parsers/VmessParser.ts
@@ -2,7 +2,7 @@ import { XrayVmessClientObject } from '../ClientsObjects';
 import { XrayParsedUrlObject, XrayStreamSettingsObject } from '../CommonObjects';
 import { XrayOutboundObject, XrayVlessOutboundObject } from '../OutboundObjects';
 
-const VlessParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVlessOutboundObject> | null => {
+export default function VlessParser(parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVlessOutboundObject> | null {
   const proxy = new XrayOutboundObject<XrayVlessOutboundObject>();
   proxy.tag = parsedObj.tag;
   proxy.settings = new XrayVlessOutboundObject();
@@ -23,6 +23,4 @@ const VlessParser = (parsedObj: XrayParsedUrlObject): XrayOutboundObject<XrayVle
   if (proxy.settings.vnext[0].users) proxy.settings.vnext[0].users.push(user);
 
   return proxy;
-};
-
-export default VlessParser;
+}

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -513,6 +513,7 @@
       "manager": "Manage Backups",
       "backup": "backup",
       "clear": "clear",
+      "hint": "Backup xray/xrayui configuration files.",
       "clear_confirm": "Are you sure you want to clear all the backups?"
     }
   }


### PR DESCRIPTION
This pull request includes several changes to improve the handling of `DOKODEMO` inbounds, refactor firewall configurations, and optimize the codebase. The most important changes include adding support for multiple `DOKODEMO` inbounds, refactoring firewall configuration functions, and improving log fetching.

### Improvements to `DOKODEMO` Inbounds:

* Added support for configuring multiple `DOKODEMO` inbounds, allowing them to be split by processing method (Direct `REDIRECT` or `TPROXY`) and network protocol (`TCP`, `UDP`, or both).

### Refactoring Firewall Configuration:

* Refactored `configure_firewall` function to scan and configure all `DOKODEMO` inbounds in one go, splitting them based on the `tproxy` flag and processing them accordingly. [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L23-R25) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L81-R90)
* Consolidated `configure_firewall_client_direct` and `configure_firewall_client_tproxy` functions to handle multiple inbounds, adding rules for each inbound based on its protocols. [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L156-R182) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R354-R373) [[3]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R388-R432)
* Improved the cleanup of firewall rules by ensuring all relevant chains and hooks are properly removed.

### Codebase Optimization:

* Replaced the custom delay function in `src/App.vue` with `engine.delay` for consistency and better code reuse.
* Removed unused import `watch` from `src/components/Logs.vue` and streamlined comments for better readability. [[1]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L61-R61) [[2]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L116-L121) [[3]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L135-L140)