### PR TITLE
feat: update unblockItemsList and add Google domain rules in routing …

### DIFF
--- a/src/components/modals/ImportConfigModal.vue
+++ b/src/components/modals/ImportConfigModal.vue
@@ -351,7 +351,7 @@
         protocolQr,
         bypassMode,
         completeSetup,
-        unblockItemsList: ['Youtube', 'Telegram', 'TikTok', 'Reddit', 'LinkedIn', 'DeviantArt', 'Flibusta', 'Wikipedia', 'Twitch', 'Disney', 'Netflix', 'Discord', 'Instagram', 'Twitter', 'Patreon', 'Metacritic', 'Envato', 'SoundCloud', 'Kinopub', 'Facebook'].sort(),
+        unblockItemsList: ['Github', 'Google', 'Youtube', 'Telegram', 'TikTok', 'Reddit', 'LinkedIn', 'DeviantArt', 'Flibusta', 'Wikipedia', 'Twitch', 'Disney', 'Netflix', 'Discord', 'Instagram', 'Twitter', 'Patreon', 'Metacritic', 'Envato', 'SoundCloud', 'Kinopub', 'Facebook'].sort(),
         unblockItems,
         select_json_file,
         select_qr,

--- a/src/modules/CommonObjects.ts
+++ b/src/modules/CommonObjects.ts
@@ -347,7 +347,7 @@ export class XrayRoutingObject {
 
         switch (gs) {
           case 'kinopub':
-            rule.ip = [`89.34.0.0/16`, `31.40.0.0/16`, `93.189.57.0/24`, `93.189.61.0/24`, `194.59.142.0/24`];
+            rule.domain = [`kino.pub`, `kinopub.online`, `gfw.ovh`, `vjs.zencdn.net`, `m.pushbr.com`, `mos-gorsud.co`, `zamerka.com`, `regexp:(\w+)-static-[0-9]+\.cdntogo\.net$`];
             break;
           case 'envato':
             rule.domain = [`domain:envato.com`, `domain:envato.net`, `domain:envatoelements.com`, `domain:envatousercontent.com`];
@@ -360,6 +360,9 @@ export class XrayRoutingObject {
             break;
           case 'wikipedia':
             rule.domain = [`geosite:wikimedia`];
+            break;
+          case 'google':
+            rule.domain = [`geosite:google`, `geosite:google-play`, `geosite:google-registry`, `geosite:google-ads`, `geosite:google-trust-services`, `geosite:google-scholar`];
             break;
           default: {
             rule.domain = [`geosite:${gs}`];

--- a/src/modules/CommonObjects.ts
+++ b/src/modules/CommonObjects.ts
@@ -347,7 +347,7 @@ export class XrayRoutingObject {
 
         switch (gs) {
           case 'kinopub':
-            rule.domain = [`kino.pub`, `kinopub.online`, `gfw.ovh`, `vjs.zencdn.net`, `m.pushbr.com`, `mos-gorsud.co`, `zamerka.com`, `regexp:(\w+)-static-[0-9]+\.cdntogo\.net$`];
+            rule.domain = [`kino.pub`, `kinopub.online`, `gfw.ovh`, `vjs.zencdn.net`, `m.pushbr.com`, `mos-gorsud.co`, `zamerka.com`, `"regexp:(\\w+)-static-[0-9]+\\.cdntogo\\.net$"`];
             break;
           case 'envato':
             rule.domain = [`domain:envato.com`, `domain:envato.net`, `domain:envatoelements.com`, `domain:envatousercontent.com`];


### PR DESCRIPTION
This pull request includes updates to the `ImportConfigModal.vue` and `CommonObjects.ts` files to enhance the configuration and routing objects. The most important changes include updating the `unblockItemsList` and modifying routing rules for specific services.

Updates to configuration:

* [`src/components/modals/ImportConfigModal.vue`](diffhunk://#diff-0313db925cffe892d91f18f6dff873bbca751285fdb383012899f9a73a9ade67L354-R354): Added 'Github' and 'Google' to the `unblockItemsList` and ensured the list is sorted.

Modifications to routing rules:

* [`src/modules/CommonObjects.ts`](diffhunk://#diff-1283fb1cda830a39bddfc5a3b1b264834a7f31d81dd736dfe75e9bdeb9b55f37L350-R350): Changed routing rules for 'kinopub' to use domain-based rules instead of IP-based rules.
* [`src/modules/CommonObjects.ts`](diffhunk://#diff-1283fb1cda830a39bddfc5a3b1b264834a7f31d81dd736dfe75e9bdeb9b55f37R364-R366): Added routing rules for 'google' to include various Google-related services.