### PR TITLE
fix: ensure rules are processed only for object types in DNS domain m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # XRAYUI Changelog
 
+## [0.43.1] - 2025-04-16
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- FIXED: an issue where non-object `DNS server entries` (like string addresses) were being dropped from the configuration.
+
 ## [0.43.0] - 2025-04-14
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/backend/response.sh
+++ b/src/backend/response.sh
@@ -160,7 +160,7 @@ rules_to_dns_domains() {
     # Rewrite .dns.servers
     | .dns.servers |= (
         map(
-          if ( .rules? | length ) > 0 then
+          if ( (type == "object") and (.rules? | length) > 0 ) then
             .domains = (
               [
                 .rules[] as $ruleId


### PR DESCRIPTION
This pull request addresses a bug fix in the `XRAYUI` project, involving changes to the changelog and a backend script to ensure proper handling of DNS server entries.

### Changelog Update:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8): Added a new entry for version 0.43.1, highlighting the fix for non-object DNS server entries being dropped from the configuration.

### Bug Fix in Backend Script:
* [`src/backend/response.sh`](diffhunk://#diff-7d11f2f9186a7d0b562bab541522489f1926982091dab525ad3defa133d415cfL163-R163): Modified the `rules_to_dns_domains` function to check if the DNS server entry is an object before processing its rules, ensuring that string addresses are not dropped.