### PR TITLE
Fix online clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # XRAYUI Changelog
 
+## [0.4x.x] - 2025-0x-xx
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- FIXED: Connected clients were not displayed correctly due to improper parsing of the access log.
+
 ## [0.43.1] - 2025-04-16
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XRAYUI Changelog
 
-## [0.4x.x] - 2025-0x-xx
+## [0.43.2] - 2025-04-16
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 

--- a/src/backend/connected_clients.sh
+++ b/src/backend/connected_clients.sh
@@ -35,7 +35,7 @@ get_connected_clients() {
 
     for ip in $ips; do
         if [ -n "$ip" ]; then
-            emails=$(grep "$ip" "$access_log" | awk -F'email: ' '{print $2}' | sort | uniq | sed 's/^/"/; s/$/"/' | tr '\n' ',' | sed 's/,$//')
+            emails=$(grep -a "$ip" "$access_log" | awk -F'email: ' '{print $2}' | sort | uniq | sed 's/^/"/; s/$/"/' | tr '\n' ',' | sed 's/,$//')
             if [ -n "$emails" ]; then
                 echo "{\"ip\": \"$ip\", \"email\": [$emails]}," >>"$temp_file"
                 # else


### PR DESCRIPTION
This pull request includes changes to the `CHANGELOG.md` file and a bug fix in the `get_connected_clients` function in the `src/backend/connected_clients.sh` script. The most important changes are listed below:

Bug Fixes:
* [`src/backend/connected_clients.sh`](diffhunk://#diff-26a0cb0b6f1cd504415406ae23f75d5a1058fc3b756e9477d7ca5f93ab86de35L38-R38): Fixed an issue where connected clients were not displayed correctly by ensuring the access log is parsed as text using the `-a` flag in the `grep` command.

Documentation:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R8): Added a new entry for version 0.4x.x, highlighting the fix for the connected clients display issue and reminding users to clear their browser cache.