### PR TITLE
fix: adjust margin for formfontdesc to align text properly

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -230,6 +230,7 @@
   }
 
   .formfontdesc {
+    margin-left: 0;
     p {
       text-align: left;
       margin-bottom: 10px;


### PR DESCRIPTION
This pull request includes a small change to the `src/App.vue` file. The change adjusts the `margin-left` property of the `.formfontdesc` class to zero.

* [`src/App.vue`](diffhunk://#diff-7a7a37b12ee1265d7e27577ec286120d2cbc0940908635e264a2be44ccb9a8a0R233): Set `margin-left` to 0 for the `.formfontdesc` class.