### PR TITLE
fix: ensure dnsmasq service restarts after enabling/disabling logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # XRAYUI Changelog
 
+## [0.4x.x] - 2025-xx-xx
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- IMPROVED: Added calls to restart the `dnsmasq` service after enabling or disabling logging, ensuring the changes take effect immediately.
+
 ## [0.43.2] - 2025-04-16
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/backend/general_opts.sh
+++ b/src/backend/general_opts.sh
@@ -55,10 +55,13 @@ apply_general_options() {
 log-queries
 log-facility=/opt/var/log/dnsmasq.log
 EOF
+
+        service restart_dnsmasq >/dev/null 2>&1 && printlog true "DNS service restarted successfully." $CSUC
         printlog true "Enabled dnsmasq logging (queries and log-facility set) on Asus Merlin."
     else
         if [ -f /jffs/configs/dnsmasq.conf.add ]; then
             rm /jffs/configs/dnsmasq.conf.add
+            service restart_dnsmasq >/dev/null 2>&1 && printlog true "DNS service restarted successfully." $CSUC
             printlog true "Disabled dnsmasq logging by removing /jffs/configs/dnsmasq.conf.add."
         fi
     fi


### PR DESCRIPTION
This pull request makes a small but important change to the `apply_general_options()` function in `src/backend/general_opts.sh`. The change ensures that the `dnsmasq` service is restarted after enabling or disabling logging, improving the reliability of the logging configuration.

* [`src/backend/general_opts.sh`](diffhunk://#diff-6a568150490654d931c1bbeb93b6410f246b157e19cb146b3806ee97abfeb5ddR58-R64): Added calls to `service restart_dnsmasq` to restart the `dnsmasq` service after enabling or disabling logging, ensuring the changes take effect immediately.