### PR TITLE
fix: improve TPROXY mode detection logic in start function

### DIFF
--- a/src/backend/control.sh
+++ b/src/backend/control.sh
@@ -8,7 +8,13 @@ start() {
 
     printlog true "Starting $ADDON_TITLE"
 
-    local TPROXY_MODE=$(jq -r '[.inbounds? // []; .[] | .streamSettings.sockopt.tproxy? // "off"]|if any(.!="off")then"on"else"off"end' "$XRAY_CONFIG_FILE")
+    local TPROXY_MODE=$(
+        jq -r '
+    .inbounds? // []
+    | map(.streamSettings.sockopt.tproxy? // "off")
+    | if any(. != "off") then "on" else "off" end
+  ' "$XRAY_CONFIG_FILE"
+    )
 
     if [ "$TPROXY_MODE" = "on" ]; then
         printlog true "TPROXY mode is $TPROXY_MODE. Increasing max open files to 65535."

--- a/src/backend/control.sh
+++ b/src/backend/control.sh
@@ -8,8 +8,9 @@ start() {
 
     printlog true "Starting $ADDON_TITLE"
 
-    local TPROXY_MODE="$(jq -r '.inbounds[0].streamSettings.sockopt.tproxy // "off"' "$XRAY_CONFIG_FILE")"
-    if [ "$TPROXY_MODE" != "off" ]; then
+    local TPROXY_MODE=$(jq -r '[.inbounds? // []; .[] | .streamSettings.sockopt.tproxy? // "off"]|if any(.!="off")then"on"else"off"end' "$XRAY_CONFIG_FILE")
+
+    if [ "$TPROXY_MODE" = "on" ]; then
         printlog true "TPROXY mode is $TPROXY_MODE. Increasing max open files to 65535."
         ulimit -Hn 65535
         ulimit -Sn 65535


### PR DESCRIPTION
This pull request updates the logic for determining TPROXY mode in the `start()` function of `src/backend/control.sh`. The change simplifies the handling of multiple inbound configurations and ensures accurate detection of TPROXY mode.

### Improvements to TPROXY mode detection:
* Updated the `TPROXY_MODE` assignment to handle multiple inbounds by using a `jq` expression that checks all inbound configurations for the presence of TPROXY mode. If any configuration has TPROXY enabled, the mode is set to "on"; otherwise, it defaults to "off".