### PR TITLE
fix: ensure logs directory is created before starting the service

### DIFF
--- a/src/backend/control.sh
+++ b/src/backend/control.sh
@@ -29,6 +29,10 @@ start() {
         rm -f "$ADDON_LOGS_DIR/xray_error.log"
     fi
 
+    if [ ! -d "$ADDON_LOGS_DIR" ]; then
+        mkdir -p "$ADDON_LOGS_DIR"
+    fi
+
     update_loading_progress "Starting $ADDON_TITLE..."
     xray -c "$XRAY_CONFIG_FILE" >/dev/null 2>&1 &
     echo $! >$XRAY_PIDFILE


### PR DESCRIPTION
This pull request includes a small but important change to ensure the existence of the `$ADDON_LOGS_DIR` directory before proceeding with operations that depend on it.

* [`src/backend/control.sh`](diffhunk://#diff-4f3a73a95a67fc8691e74228a1714d4bceb12a37c54d21bd0cb7f738a63affe0R32-R35): Added a check to verify if `$ADDON_LOGS_DIR` exists and create it if it does not, ensuring the script does not fail when the directory is missing.