### PR TITLE
feat: Enhance response handling with cache-busting and improve service restart logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - IMPROVED: Prerelease and draft versions of `Xray Core` are now excluded from the update list.
 - IMPROVED: Update response handling and improve loading progress management.
 - IMPROVED: Enhanced the Xray version switch module to support switching to a specific version or the latest release. Use `xrayui update xray xx.xx.xx` or `xrayui update xray latest` to switch Xray-core versions directly from the CLI.
+- IMPROVED: Enhance response handling with cache-busting and improve service restart logic.
 
 ## [0.44.3] - 2025-04-20
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -36,7 +36,7 @@
             window.show_menu();
           }
           await engine.loadXrayConfig();
-          await engine.submit(SubmitActions.initResponse);
+          await engine.submit(SubmitActions.initResponse, null, 0);
           // Use our delay helper instead of setTimeout inside an async function.
           await engine.delay(1000);
           uiResponse.value = await engine.getXrayResponse();

--- a/src/backend/_helper.sh
+++ b/src/backend/_helper.sh
@@ -211,6 +211,8 @@ load_ui_response() {
 
 save_ui_response() {
 
+    log_debug "Saving UI response to $UI_RESPONSE_FILE"
+
     if ! echo "$UI_RESPONSE" >"$UI_RESPONSE_FILE"; then
         log_error "Failed to save UI response to $UI_RESPONSE_FILE"
         clear_lock

--- a/src/backend/general_opts.sh
+++ b/src/backend/general_opts.sh
@@ -72,12 +72,8 @@ apply_general_options() {
     # Update the cron job for geodata update
     cron_geodata_add
 
-    update_loading_progress "Restarting DNS service..."
-    if service restart_dnsmasq >/dev/null 2>&1; then
-        log_ok "DNS service restarted successfully."
-    else
-        log_error "Failed to restart DNS service."
+    if [ -f "$XRAY_PIDFILE" ]; then
+        update_loading_progress "Restarting Xray service..."
+        restart
     fi
-
-    restart
 }

--- a/src/backend/response.sh
+++ b/src/backend/response.sh
@@ -4,6 +4,7 @@
 initial_response() {
     load_ui_response
     load_xrayui_config
+    log_debug "Initial response started."
 
     local geoip_file="/opt/sbin/geoip.dat"
     local geosite_file="/opt/sbin/geosite.dat"
@@ -87,11 +88,10 @@ initial_response() {
 
     save_ui_response
 
-    log_debug "UI_RESPONSE: $UI_RESPONSE"
     if [ $? -eq 0 ]; then
         log_ok "Saved initial response successfully."
     else
-        log_error "Failed to save file dates to $UI_RESPONSE_FILE."
+        log_error "Failed to save file to $UI_RESPONSE_FILE."
         return 1
     fi
 }

--- a/src/backend/xrayui.sh
+++ b/src/backend/xrayui.sh
@@ -121,6 +121,7 @@ service_event)
         ;;
     update)
         update
+        initial_response
         update_loading_progress "Update process completed!" 100
         exit 0
         ;;
@@ -198,31 +199,41 @@ service_event)
             ;;
         applygeneraloptions)
             apply_general_options
+            initial_response
             update_loading_progress "General settings applied." 100
             ;;
         xrayversionswitch)
             switch_xray_version
-            restart
+            initial_response
+            if [ -f "$XRAY_PIDFILE" ]; then
+                update_loading_progress "Restarting Xray service..."
+                restart
+            fi
             update_loading_progress "Switched Xray version successfully!" 100
             ;;
         changeprofile)
             change_config_profile
+            initial_response
             update_loading_progress "Configuration profile changed successfully." 100
             ;;
         deleteprofile)
             delete_config_profile
+            initial_response
             update_loading_progress "Configuration profile deleted successfully." 100
             ;;
         backup)
             backup_configuration
+            initial_response
             update_loading_progress "Backup created successfully" 100
             ;;
         backupclearall)
             backup_clearall
+            initial_response
             update_loading_progress "Clear all completed." 100
             ;;
         backuprestore)
             backup_restore_configuration
+            initial_response
             update_loading_progress "Restore complete." 100
             ;;
         esac

--- a/src/modules/Engine.ts
+++ b/src/modules/Engine.ts
@@ -270,7 +270,13 @@ class Engine {
     return response.connection_check;
   }
   async getXrayResponse(): Promise<EngineResponseConfig> {
-    const response = await axios.get<EngineResponseConfig>('/ext/xrayui/xray-ui-response.json');
+    const response = await axios.get<EngineResponseConfig>(`/ext/xrayui/xray-ui-response.json?_=${Date.now()}`, {
+      headers: {
+        'Cache-Control': 'no-cache',
+        Pragma: 'no-cache',
+        Expires: '0'
+      }
+    });
     let responseConfig = response.data;
     return responseConfig;
   }
@@ -313,7 +319,13 @@ class Engine {
   async loadXrayConfig(config?: XrayObject): Promise<XrayObject | null> {
     try {
       if (!config) {
-        const response = await axios.get<XrayObject>('/ext/xrayui/xray-config.json');
+        const response = await axios.get<XrayObject>(`/ext/xrayui/xray-config.json?_=${Date.now()}`, {
+          headers: {
+            'Cache-Control': 'no-cache',
+            Pragma: 'no-cache',
+            Expires: '0'
+          }
+        });
         config = plainToInstance(XrayObject, response.data);
       }
       this.xrayConfig = config;


### PR DESCRIPTION
This pull request introduces several improvements to response handling, caching, and service restart logic, as well as enhancements to the backend's initialization and update processes. The changes focus on improving user experience, debugging capabilities, and system reliability.

### Backend Enhancements:

* Added `initial_response` calls to multiple service events in `src/backend/xrayui.sh` to ensure the UI response is refreshed after key operations like updates, general option applications, and profile changes. [[1]](diffhunk://#diff-f1cb4db0bd6759ab8f3a312de0bbcf39a0b4113f7377264cdd5933a64b365d38R124) [[2]](diffhunk://#diff-f1cb4db0bd6759ab8f3a312de0bbcf39a0b4113f7377264cdd5933a64b365d38R202-R236)
* Improved logging for debugging by adding `log_debug` statements to track the saving of UI responses and the start of the initial response process. [[1]](diffhunk://#diff-1530c9b6abbb66fd522efdc456cfe3d88f9a70e79039d0177247d3edd13e469eR214-R215) [[2]](diffhunk://#diff-7d11f2f9186a7d0b562bab541522489f1926982091dab525ad3defa133d415cfR7)

### Response and Caching Improvements:

* Enhanced response handling in `src/modules/Engine.ts` by implementing cache-busting for requests to `/ext/xrayui/xray-ui-response.json` and `/ext/xrayui/xray-config.json`, along with adding HTTP headers to disable caching. [[1]](diffhunk://#diff-56049b74e263416a64ed5f75cc57c3cf1caa1224aec2b9a3e8900b7ffae210d4L273-R279) [[2]](diffhunk://#diff-56049b74e263416a64ed5f75cc57c3cf1caa1224aec2b9a3e8900b7ffae210d4L316-R328)

### Service Restart Logic:

* Updated `apply_general_options` in `src/backend/general_opts.sh` to restart the Xray service instead of the DNS service, ensuring the correct service is managed during general option applications.

### Frontend Adjustments:

* Modified `src/App.vue` to pass additional parameters (`null, 0`) to the `engine.submit` method, aligning with updated response handling requirements.

### Minor Fixes:

* Corrected error message in `src/backend/response.sh` when saving the UI response fails, improving clarity.