### PR TITLE
feat: Enhance dokodemo-door support and firewall configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # XRAYUI Changelog
 
-## [0.4x.x] - 2025-xx-xx
+## [0.46.0] - 2025-xx-xx
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 
 - FIXED: `Json` configuration import.
+- ADDED: `DNAT` support for `dokodemo‑door` inbounds bound to a specific listen address (anything other than `0.0.0.0`)—those rules now use `-j DNAT --to-destination` instead of a generic `REDIRECT`.
+- ADDED: Source‑subnet filtering in client mode—all `dokodemo-door` REDIRECT/TPROXY rules are now prefixed with `-s <local_lan_subnet>`, so only LAN traffic is captured.
+- ADDED: listen‑address restriction for server inbounds—ACCEPT rules for `non‑0.0.0.0` binds now include `-d <listen_ip>`, limiting them to the configured interface.
 
 ## [0.45.0] - 2025-04-21
 

--- a/src/modules/InboundObjects.ts
+++ b/src/modules/InboundObjects.ts
@@ -28,7 +28,7 @@ export class XrayInboundObject<TProxy extends IProtocolType> {
 
   normalize = () => {
     this.tag = this.tag === '' ? undefined : this.tag;
-    this.listen = this.listen == '' ? undefined : this.listen;
+    this.listen = this.listen === '' ? undefined : this.listen;
 
     if (this.streamSettings) {
       this.streamSettings = plainToInstance(XrayStreamSettingsObject, this.streamSettings) as XrayStreamSettingsObject;

--- a/src/modules/InboundObjects.ts
+++ b/src/modules/InboundObjects.ts
@@ -28,6 +28,7 @@ export class XrayInboundObject<TProxy extends IProtocolType> {
 
   normalize = () => {
     this.tag = this.tag === '' ? undefined : this.tag;
+    this.listen = this.listen == '' ? undefined : this.listen;
 
     if (this.streamSettings) {
       this.streamSettings = plainToInstance(XrayStreamSettingsObject, this.streamSettings) as XrayStreamSettingsObject;


### PR DESCRIPTION
This pull request introduces new features and enhancements to the XRAYUI project, including updates to the changelog and modifications to the `XrayInboundObject` class for improved configuration handling.

### Changelog updates:
* Added `DNAT` support for `dokodemo-door` inbounds with specific listen addresses, enabling the use of `-j DNAT --to-destination` instead of `REDIRECT`.
* Introduced source-subnet filtering in client mode, ensuring `dokodemo-door` REDIRECT/TPROXY rules capture only LAN traffic by prefixing them with `-s <local_lan_subnet>`.
* Added listen-address restriction for server inbounds, limiting ACCEPT rules for `non‑0.0.0.0` binds to the configured interface using `-d <listen_ip>`.

### Codebase enhancements:
* Updated the `normalize` method in `XrayInboundObject` to handle empty `listen` values by setting them to `undefined`, aligning with the handling of the `tag` property.