### PR TITLE
fix: update TPROXY fwmark values in firewall configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production vite build",
+    "tar": "cross-env NODE_ENV=production vite build && tar --transform 's|^|xrayui/|' -czf asuswrt-merlin-xrayui.tar.gz -C dist .",
     "watch": "cross-env NODE_ENV=development VITE_WATCH=1 vite build --watch --mode development",
     "watch-prod": "cross-env NODE_ENV=production VITE_WATCH=1 vite build --watch --mode production"
   },


### PR DESCRIPTION
This pull request introduces a new script for packaging the project as a tarball and updates the firewall configuration to simplify and standardize the use of `fwmark` and routing rules. Below is a summary of the most important changes:

### Build and Packaging Updates:
* Added a new `tar` script in `package.json` to build the project and package it into a tarball with a directory prefix (`xrayui/`). This is useful for distribution and deployment.

### Firewall Configuration Updates:
* Updated `fwmark` values and routing table numbers in `src/backend/firewall.sh` to use `0x77` and `table 77` instead of the previous `0x8777` and `table 8777`. This change simplifies the configuration and ensures consistency:
  - Modified `IPT_JOURNAL_FLAGS` to use the new `fwmark` value.
  - Updated the `ip rule` and `ip route` commands to reflect the new `fwmark` and table numbers.
  - Adjusted cleanup logic to delete the updated `fwmark` rules and flush the new routing table.