### PR TITLE
Firewall improvements

### DIFF
--- a/src/backend/install.sh
+++ b/src/backend/install.sh
@@ -120,9 +120,7 @@ EOF
 
     local json_content=$(cat "$XRAY_CONFIG_FILE")
 
-    # patch 0.44.1 -> 0.44.2
-    rm -f /jffs/configs/dnsmasq.conf.add
-
+    log_ok "Installed $(show_version)"
     log_box "Installation process completed successfully."
 
     update_loading_progress "Installation completed successfully."

--- a/src/backend/response.sh
+++ b/src/backend/response.sh
@@ -52,7 +52,7 @@ initial_response() {
 
     local dnsmasq_enabled=false
     # look in both the main conf _and_ any .add file
-    for f in /etc/dnsmasq.conf /jffs/configs/dnsmasq.conf.add; do
+    for f in /etc/dnsmasq.conf; do
         [ -f "$f" ] || continue
         grep -qE '^\s*log-queries' "$f" &&
             grep -qE '^\s*log-facility=.*dnsmasq\.log' "$f" && dnsmasq_enabled=true && log_debug "dnsmasq enabled in $f"


### PR DESCRIPTION
This pull request refactors the firewall configuration scripts in `src/backend/firewall.sh` to simplify logic, improve maintainability, and enhance functionality. Key changes include adjustments to how inbound and outbound rules are applied, updates to TPROXY handling, and the removal of deprecated configuration references.

### Firewall Rule Adjustments:
* Simplified the logic for handling inbound rules by consolidating address-specific conditions and dynamically constructing `iptables` flags. This reduces redundancy and improves readability. (`[src/backend/firewall.shL112-R121](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L112-R121)`)
* Removed the exclusion of inbounds with tags starting with `sys:` while retaining the exclusion for the `dokodemo-door` protocol. (`[src/backend/firewall.shL91-R91](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L91-R91)`)

### TPROXY Enhancements:
* Added exclusions for WAN IP, non-default static routes, and custom static routes in TPROXY mode to ensure proper traffic handling. (`[src/backend/firewall.shR222-R246](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R222-R246)`)
* Updated TPROXY rules to dynamically handle `dokodemo-door` addresses, improving flexibility for different inbound configurations. (`[src/backend/firewall.shL238-R270](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L238-R270)`)

### Code Simplifications:
* Consolidated logic for bypass rules in `DIRECT` mode, ensuring consistent behavior across different configurations. (`[src/backend/firewall.shR348-R350](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R348-R350)`)
* Declared variables locally within loops and functions to improve scope management and prevent potential conflicts. (`[src/backend/firewall.shL238-R270](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L238-R270)`)

### Removal of Deprecated References:
* Removed references to the outdated `dnsmasq.conf.add` configuration file in both installation and response scripts. (`[[1]](diffhunk://#diff-a46228565461e80f30ec983b146342b33fcae1e373eb412b01bf3f32d91d2fb0L123-R123)`, `[[2]](diffhunk://#diff-7d11f2f9186a7d0b562bab541522489f1926982091dab525ad3defa133d415cfL55-R55)`)