### PR TITLE
fix: streamline dokodemo-door protocol handling in firewall configura…

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "cross-env NODE_ENV=production vite build",
-    "tar": "cross-env NODE_ENV=production vite build && VERSION=${npm_config_version:-latest} && echo \"› XRAYUI_VERSION=$VERSION\" && sed -i \"s|^XRAYUI_VERSION=.*|XRAYUI_VERSION=\\\"$VERSION\\\"|\" dist/xrayui && set -- && tar --transform 's|^|xrayui/|' -czf \"asuswrt-merlin-xrayui-$VERSION.tar.gz\" -C dist .",
+    "watch": "cross-env NODE_ENV=development VITE_WATCH=1 vite build --watch --mode development",
     "watch-prod": "cross-env NODE_ENV=production VITE_WATCH=1 vite build --watch --mode production"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request introduces changes to streamline the firewall configuration logic, improve maintainability, and add new build scripts. The key updates include refactoring repeated code into a reusable function, enhancing the handling of routing policies, and adding new scripts for development and production builds.

### Firewall Configuration Improvements:

* **Refactored `route_localnet` logic into a reusable function**: Added a new `set_route_localnet()` function to simplify enabling/disabling `route_localnet` on LAN and TUN interfaces. This replaces repeated code in `configure_firewall()` and `cleanup_firewall()` with a single, maintainable implementation. (`src/backend/firewall.sh`: [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L417-R423) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R443-R455)

* **Updated `dokodemo-door` inbound handling**: Modified the logic to check if the `listen` field starts with `127.` instead of comparing against `"0.0.0.0"`. This change applies to both `configure_firewall()` and `cleanup_firewall()` functions for consistency. (`src/backend/firewall.sh`: [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L32-R35) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L417-R423)

* **Improved logging and rule application**: Enhanced logging for applied policies, including details about policy mode, TCP/UDP ports, and MAC count. Also updated success messages to use the correct `$IPT_TYPE` variable for clarity. (`src/backend/firewall.sh`: [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L292-R302) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L388-R391)

### Build Script Enhancements:

* **Added watch scripts for development and production**: Introduced `watch` and `watch-prod` scripts to enable live rebuilds during development and production modes, respectively. These scripts replace the removed `tar` script in `package.json`. (`package.json`: [package.jsonL7-R7](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R7))