### PR TITLE
feat: add filtering options for logs by source, target, inbound, and …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XRAYUI Changelog
 
-## [0.46.0] - 2025-xx-xx
+## [0.46.0] - 2025-04-24
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 
@@ -8,6 +8,8 @@
 - ADDED: `DNAT` support for `dokodemo‑door` inbounds bound to a specific listen address (anything other than `0.0.0.0`)—those rules now use `-j DNAT --to-destination` instead of a generic `REDIRECT`.
 - ADDED: Source‑subnet filtering in client mode—all `dokodemo-door` REDIRECT/TPROXY rules are now prefixed with `-s <local_lan_subnet>`, so only LAN traffic is captured.
 - ADDED: listen‑address restriction for server inbounds—ACCEPT rules for `non‑0.0.0.0` binds now include `-d <listen_ip>`, limiting them to the configured interface.
+- ADDED: Filtering options for logs by source, target, inbound, and outbound in Logs component.
+- IMPROVED: Moved logs window to a modal.
 
 ## [0.45.0] - 2025-04-21
 

--- a/src/components/Logs.vue
+++ b/src/components/Logs.vue
@@ -31,7 +31,7 @@
                         </tr>
                       </thead>
                       <tbody class="logs-area-content">
-                        <tr v-for="(log, index) in parsedLogs" :key="index" :class="[log.parsed ? 'parsed' : 'unparsed']">
+                        <tr v-for="(log, index) in filteredLogs" :key="index" :class="[log.parsed ? 'parsed' : 'unparsed']">
                           <!-- Parsed entry (normal layout) -->
                           <template v-if="log.parsed">
                             <td>{{ log.time }}</td>
@@ -57,6 +57,23 @@
                           <td colspan="5">No logs available</td>
                         </tr>
                       </tbody>
+                      <tbody>
+                        <tr class="filter-row">
+                          <td></td>
+                          <td>
+                            <input v-model.trim="filters.source" placeholder="🔎 source" class="input_20_table" />
+                          </td>
+                          <td>
+                            <input v-model.trim="filters.target" placeholder="🔎 target" class="input_20_table" />
+                          </td>
+                          <td>
+                            <input v-model.trim="filters.inbound" placeholder="🔎 inbound" class="input_20_table" />
+                          </td>
+                          <td>
+                            <input v-model.trim="filters.outbound" placeholder="🔎 outbound" class="input_20_table" />
+                          </td>
+                        </tr>
+                      </tbody>
                     </table>
                   </div>
                 </div>
@@ -70,7 +87,7 @@
 </template>
 
 <script lang="ts">
-  import { defineComponent, onMounted, onBeforeUnmount, ref, computed } from 'vue';
+  import { defineComponent, onMounted, onBeforeUnmount, ref, computed, reactive } from 'vue';
   import axios from 'axios';
   import engine, { SubmitActions } from '@/modules/Engine';
   import { XrayLogObject } from '@/modules/CommonObjects';
@@ -148,6 +165,25 @@
       const FILE_ERROR = '/ext/xrayui/xray_error_partial.asp';
       const file = ref<string>(FILE_ACCESS);
       const logsContent = ref<string>('');
+      const filters = reactive({
+        source: '',
+        target: '',
+        inbound: '',
+        outbound: ''
+      });
+
+      const filteredLogs = computed<AccessLogEntry[]>(() => {
+        return parsedLogs.value.filter((l) => {
+          if (!l.parsed) return true;
+
+          const s = filters.source.toLowerCase();
+          const t = filters.target.toLowerCase();
+          const i = filters.inbound.toLowerCase();
+          const o = filters.outbound.toLowerCase();
+
+          return (!s || l.source?.toLowerCase().includes(s) || l.source_device?.toLowerCase().includes(s)) && (!t || `${l.target}:${l.target_port}`.toLowerCase().includes(t)) && (!i || l.inbound?.toLowerCase().includes(i)) && (!o || l.outbound?.toLowerCase().includes(o));
+        });
+      });
 
       const devices = computed(() => {
         return Object.fromEntries(Object.entries(window.xray.router.devices_online).map(([mac, device]) => [device.ip, device]));
@@ -202,7 +238,9 @@
         parsedLogs,
         FILE_ACCESS,
         FILE_ERROR,
-        display
+        filters,
+        display,
+        filteredLogs
       };
     }
   });
@@ -275,6 +313,25 @@
     }
     tr.unparsed td {
       color: #888;
+    }
+
+    .filter-row {
+      background: #2b3538;
+
+      .filter-input {
+        width: 100%;
+        padding: 2px 4px;
+        border: 1px solid #555;
+        border-radius: 4px;
+        background: #414d51;
+        color: #fff;
+        font-size: 11px;
+
+        &:focus {
+          outline: none;
+          border-color: #00ff7f;
+        }
+      }
     }
   }
 </style>

--- a/src/components/Logs.vue
+++ b/src/components/Logs.vue
@@ -31,7 +31,7 @@
                         </tr>
                       </thead>
                       <tbody class="logs-area-content">
-                        <tr v-for="(log, index) in filteredLogs" :key="index" :class="[log.parsed ? 'parsed' : 'unparsed']">
+                        <tr v-for="log in filteredLogs" :key="log.line" :class="[log.parsed ? 'parsed' : 'unparsed']">
                           <!-- Parsed entry (normal layout) -->
                           <template v-if="log.parsed">
                             <td>{{ log.time }}</td>
@@ -317,21 +317,6 @@
 
     .filter-row {
       background: #2b3538;
-
-      .filter-input {
-        width: 100%;
-        padding: 2px 4px;
-        border: 1px solid #555;
-        border-radius: 4px;
-        background: #414d51;
-        color: #fff;
-        font-size: 11px;
-
-        &:focus {
-          outline: none;
-          border-color: #00ff7f;
-        }
-      }
     }
   }
 </style>


### PR DESCRIPTION
This pull request introduces enhancements to the Logs component, including new filtering capabilities and UI improvements, along with updates to the changelog to document these changes. The most important updates are grouped below by theme.

### Feature Enhancements:
* Added filtering options for logs by `source`, `target`, `inbound`, and `outbound` in the Logs component. These filters are implemented using a `reactive` object and a `computed` property to dynamically filter logs based on user input. (`src/components/Logs.vue`: [[1]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1R60-R76) [[2]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1R168-R186) [[3]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L205-R243)

### UI Improvements:
* Moved the logs window to a modal for better user experience. (Documented in `CHANGELOG.md`: [CHANGELOG.mdL3-R12](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R12))
* Added a dedicated filter row in the logs table with styled input fields for filtering logs. (`src/components/Logs.vue`: [[1]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1R60-R76) [[2]](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1R317-R335)

### Code Adjustments:
* Updated the `v-for` loop in the logs table to use `filteredLogs` instead of `parsedLogs`, ensuring the displayed logs respect the applied filters. (`src/components/Logs.vue`: [src/components/Logs.vueL34-R34](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L34-R34))
* Imported `reactive` from Vue to manage the state of the new filters. (`src/components/Logs.vue`: [src/components/Logs.vueL73-R90](diffhunk://#diff-4085e95c9e5f5911b63c923504ec24929052212600168b9be28c05d0ef8c8ce1L73-R90))

### Documentation:
* Updated the `CHANGELOG.md` to reflect the new features and improvements, including the addition of log filtering and the modal for the logs window. (`CHANGELOG.md`: [CHANGELOG.mdL3-R12](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R12))