### PR TITLE
fix: wrap feature checks in load event listener for better execution …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XRAYUI Changelog
 
-## [0.46.0] - 2025-04-24
+## [0.46.1] - 2025-04-24
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 

--- a/src/App.html
+++ b/src/App.html
@@ -62,13 +62,15 @@
         link.href = 'https://cdn.jsdelivr.net/gh/lipis/flag-icons@7.2.3/css/flag-icons.min.css';
         document.head.appendChild(link);
       }
-      if (xray.router.features) {
-        if (xray.router.features.indexOf('rog') !== -1) {
-          document.body.classList.add('xrayui-rog');
-        } else if (xray.router.features.indexOf('tuf') !== -1) {
-          document.body.classList.add('xrayui-tuf');
+      window.addEventListener('load', function () {
+        if (xray.router.features) {
+          if (xray.router.features.indexOf('rog') !== -1) {
+            document.body.classList.add('xrayui-rog');
+          } else if (xray.router.features.indexOf('tuf') !== -1) {
+            document.body.classList.add('xrayui-tuf');
+          }
         }
-      }
+      });
     </script>
     <script type="module" src="/ext/xrayui/app.js"></script>
   </body>


### PR DESCRIPTION
This pull request introduces a small but significant change to the `src/App.html` file. The change ensures that feature-based class additions to the `body` element are executed only after the page has fully loaded.

* [`src/App.html`](diffhunk://#diff-7a8678681459becb339ae2cfa0b7614d46210d42bc8fcd8c7dbea050f8281a0fR65-R73): Wrapped the logic for adding feature-based classes (`xrayui-rog` or `xrayui-tuf`) to the `body` element inside a `window.addEventListener('load', ...)` block to ensure it runs after the page load event.