### PR TITLE
Clamp mss to pmtu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XRAYUI Changelog
 
-## [0.47.0] - 2025-04-27
+## [0.47.1] - 2025-04-27
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 
 - ADDED: `IPv6` support.
+- ADDED: Added a rule to clamp the `TCP MSS` to the path `MTU` for all forwarded SYN packets in both `IPv4` and `IPv6`. This improves TCP performance by avoiding fragmentation.
 - IMPROVED: Diagnostics provides more useful information.
 
 ## [0.46.6] - 2025-04-25


### PR DESCRIPTION
This pull request includes a version bump in the changelog and updates to the firewall configuration script to enhance TCP performance and ensure proper cleanup. The most important changes include clamping the TCP MSS to the path MTU for forwarded SYN packets, ensuring the TPROXY module is loaded, and cleaning up the new firewall rule during teardown.

### Versioning:
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL3-R3): Updated the version from `0.47.0` to `0.47.1`.

### Firewall Configuration Enhancements:
* [`src/backend/firewall.sh`](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R59-R62): Added a rule to clamp the TCP MSS to the path MTU for all forwarded SYN packets in both IPv4 and IPv6 (`configure_firewall`). This improves TCP performance by avoiding fragmentation.
* [`src/backend/firewall.sh`](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R189): Ensured the `xt_TPROXY` kernel module is loaded when configuring the firewall for client traffic (`configure_firewall_client`).

### Firewall Cleanup:
* [`src/backend/firewall.sh`](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R456-R457): Added cleanup logic to remove the TCP MSS clamping rule during firewall teardown (`cleanup_firewall`).