### PR TITLE
chore: update CHANGELOG for version 0.47.14 and enhance firewall conf…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 
-- ADDED: Check `JFFS` partition check during the installation.
+- ADDED: Verify the readiness of the router's `JFFS` partition during installation, ensuring that required configurations are enabled.
 - IMPROVED: Enhance `TPROXY` rules and improve exclusion handling in firewall configuration.
 - ADDED: Added rules to exclude traffic destined for the router's IP on `UDP` port `53`.
-- ADDED: Introduced connection marking rules to handle locally-owned `UDP` sockets more effectively.
-- ADDED: Added a rule to exclude traffic in the DNAT state, covering inbound port forwards.
+- ADDED: Enhanced `TPROXY` rules by introducing connection marking for locally-owned `UDP` sockets and saving marks to improve traffic handling.
+- ADDED: Added rules to exclude traffic for specific tunnel UDP ports (`500`, `4500`, `51820`).
 
 ## [0.47.11] - 2025-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # XRAYUI Changelog
 
+## [0.47.14] - 2025-04-29
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
 ## [0.47.11] - 2025-04-27
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # XRAYUI Changelog
 
-## [0.47.14] - 2025-04-29
+## [0.48.0] - 2025-04-29
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- ADDED: Check `JFFS` partition check during the installation.
+- IMPROVED: Enhance `TPROXY` rules and improve exclusion handling in firewall configuration.
+- ADDED: Added rules to exclude traffic destined for the router's IP on `UDP` port `53`.
+- ADDED: Introduced connection marking rules to handle locally-owned `UDP` sockets more effectively.
+- ADDED: Added a rule to exclude traffic in the DNAT state, covering inbound port forwards.
 
 ## [0.47.11] - 2025-04-27
 

--- a/src/backend/install.sh
+++ b/src/backend/install.sh
@@ -1,10 +1,33 @@
 #!/bin/sh
 # shellcheck disable=SC2034  # codacy:Unused variables
 
+check_jffs_ready() {
+
+    if [ "$(nvram get jffs2_on 2>/dev/null)" != "1" ]; then
+        log_error "JFFS partition is DISABLED (nvram jffs2_on=0)."
+        log_error "Enable it under Administration ▸ System, or run:"
+        log_error "    nvram set jffs2_on=1 && nvram commit && reboot"
+        exit 1
+    else
+        log_info "JFFS partition is ENABLED."
+    fi
+
+    if [ "$(nvram get jffs2_scripts 2>/dev/null)" != "1" ]; then
+        log_error "JFFS custom scripts and configs are DISABLED."
+        log_error "Enable it in the router UI (Administration ▸ System) or run:"
+        log_error "    nvram set jffs2_scripts=1 && nvram commit && reboot"
+        exit 1
+    else
+        log_info "JFFS custom scripts and configs are ENABLED."
+    fi
+}
+
 install() {
 
     update_loading_progress "Installing $ADDON_TITLE..."
     log_info "Starting $ADDON_TITLE installation process."
+
+    check_jffs_ready
 
     load_xrayui_config
 


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the XRAYUI project, primarily focusing on improving firewall configuration, adding new exclusion rules, and ensuring compatibility with the router's JFFS partition. Below are the key changes grouped by theme:

### Firewall Configuration Improvements
* Enhanced `TPROXY` rules by introducing connection marking for locally-owned `UDP` sockets and saving marks to improve traffic handling. (`src/backend/firewall.sh`, [src/backend/firewall.shR241-R254](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R241-R254))
* Added rules to exclude traffic destined for the router's IP on `UDP` port `53` and traffic in the DNAT state (inbound port forwards). (`src/backend/firewall.sh`, [[1]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R241-R254) [[2]](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R289-R308)
* Updated exclusion rules to handle specific networks (`10.10.10.0/24`) and differentiate between `TCP` and `UDP` traffic for certain cases. (`src/backend/firewall.sh`, [src/backend/firewall.shL256-R275](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L256-R275))

### New Features
* Introduced a `check_jffs_ready()` function to verify the readiness of the router's JFFS partition during installation, ensuring that required configurations are enabled. (`src/backend/install.sh`, [src/backend/install.shR4-R31](diffhunk://#diff-a46228565461e80f30ec983b146342b33fcae1e373eb412b01bf3f32d91d2fb0R4-R31))

### Miscellaneous Enhancements
* Added rules to exclude traffic for specific tunnel `UDP` ports (`500`, `4500`, `51820`) and removed unused or redundant code related to QUIC size-gating. (`src/backend/firewall.sh`, [src/backend/firewall.shR289-R308](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012R289-R308))
* Updated the changelog to document these changes and improvements in version `0.48.0`. (`CHANGELOG.md`, [CHANGELOG.mdR3-R12](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R12))