### PR TITLE
chore: update CHANGELOG for version 0.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # XRAYUI Changelog
 
-## [0.48.0] - 2025-04-29
+## [0.48.1] - 2025-04-29
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [0.48.1] - 2025-04-29
 
+- REMOVED: rules excluding `STUN` (WebRTC) traffic.
+- REMOVED: the priority `101` parameter in the `ip rule add` command for policy rules.
+
+## [0.48.0] - 2025-04-29
+
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
 
 - ADDED: Verify the readiness of the router's `JFFS` partition during installation, ensuring that required configurations are enabled.


### PR DESCRIPTION
This pull request includes minor updates to the `CHANGELOG.md` file and several adjustments to the `firewall.sh` script, primarily focused on improving clarity, removing redundant rules, and simplifying configurations.

### Updates to `CHANGELOG.md`:
* Updated the version number from `0.48.0` to `0.48.1` to reflect the latest changes.

### Adjustments to `firewall.sh`:
#### Code cleanup and simplification:
* Removed a commented line in the `configure_firewall_client()` function for better readability.
* Removed the exclusion rule for STUN (WebRTC) traffic in the `configure_firewall_client()` function, simplifying the configuration.

#### Configuration refinement:
* Adjusted the `add_tproxy_routes()` function to remove the `priority 101` parameter from the `ip rule add` and `ip rule replace` commands, streamlining the policy rule setup.