### PR TITLE
feat: Remove explicit restart of firewall and dnsmasq services in cle…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # XRAYUI Changelog
 
+## [0.49.4] - 2025-05-07
+
+- IMPROVED: Removed explicit restart of the `firewall` and `dnsmasq` services.
+
 ## [0.49.3] - 2025-05-06
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/backend/firewall.sh
+++ b/src/backend/firewall.sh
@@ -561,7 +561,7 @@ cleanup_firewall() {
         [ "$fam" = "-6" ] && ! is_ipv6_enabled && continue
         for m in 0x10000/0x10000 0x8777 0x77; do
             while ip $fam rule show | grep -q "fwmark $tproxy_mark"; do
-                ip $fam rule del fwmark $tproxy_mark/$tproxy_mask lookup $tproxy_table 2>/dev/null
+                ip $fam rule del lookup $tproxy_table 2>/dev/null
             done
         done
     done
@@ -587,12 +587,6 @@ cleanup_firewall() {
         log_info "Executing user firewall script: $script"
         "$script" "$XRAY_CONFIG_FILE" || log_error "Error executing $script."
     fi
-
-    log_info "Restarting firewall and DNS services..."
-    update_loading_progress "Restarting firewall and DNS services..."
-
-    { service restart_firewall >/dev/null 2>&1 && log_ok "Firewall service restarted successfully."; } ||
-        log_error "Failed to restart firewall service."
 
     if [ "$POST_RESTART_DNSMASQ" = "false" ]; then
         dnsmasq_restart


### PR DESCRIPTION
This pull request includes changes to streamline the handling of firewall rules and service restarts in the XRAYUI backend. The most important changes involve removing redundant service restarts and simplifying firewall rule cleanup logic.

### Improvements to service handling:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R6): Updated to reflect the removal of explicit restarts for the `firewall` and `dnsmasq` services as part of version 0.49.4.
* [`src/backend/firewall.sh`](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L591-L596): Removed the explicit restart of the `firewall` service and associated logging, as it is no longer necessary.

### Code simplification:

* [`src/backend/firewall.sh`](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L564-R564): Simplified the `cleanup_firewall` function by removing the redundant `fwmark` parameter from the `ip rule del` command, as the `tproxy_table` lookup is sufficient.