### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: "0.1"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/security/code-scanning/2](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/security/code-scanning/2)

To fix the issue, add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository contents and uploads artifacts. Therefore, the `contents: read` permission is sufficient, as no write operations to the repository are performed. If additional permissions are required in the future, they can be added explicitly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
