### PR TITLE
Fix missing function call in uninstall script

### DIFF
--- a/src/backend/install.sh
+++ b/src/backend/install.sh
@@ -250,7 +250,7 @@ uninstall() {
 
     if [ "$user_input" = "yes" ] || [ "$user_input" = "y" ]; then
         log_info "Removing  BACKUPS..."
-        backup_clearall
+        backup_clear
     else
         log_info "Keeping  BACKUPS."
     fi


### PR DESCRIPTION
## Summary
- correct backup removal call in `src/backend/install.sh`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750ec55258832fa74f2415f8f724e0