### PR TITLE
Fix diagnostics config variable

### DIFF
--- a/src/backend/diagnostics.sh
+++ b/src/backend/diagnostics.sh
@@ -83,7 +83,7 @@ diagnostics_xray() {
     log_info
 
     log_info "Xray config:"
-    cat "$XRAY_CONFIG" 2>&1
+    cat "$XRAY_CONFIG_FILE" 2>&1
     log_info "--------------------------------------------------------"
     log_info
 


### PR DESCRIPTION
## Summary
- fix invalid variable name in diagnostics.sh

## Testing
- `sh -n src/backend/diagnostics.sh`
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68750ec55258832fa74f2415f8f724e0