### PR TITLE
fix: streamline firewall rule handling for TCP/UDP in redirect mode

### DIFF
--- a/src/backend/firewall.sh
+++ b/src/backend/firewall.sh
@@ -561,16 +561,15 @@ configure_firewall_client() {
                 base="-s $src"
                 for mac in $macs; do
                     [ "$mac" = "ANY" ] && mac_flag="" || mac_flag="-m mac --mac-source $mac"
-                    [ "$policy_mode" = "bypass" ] && ports_mark="!" || ports_mark=""
-
-                    [ "$tcp_enabled" = "yes" ] && [ -n "$tcp_ports" ] && insert_rule "$IPT_TABLE" $base $mac_flag -p tcp -m multiport $ports_mark --dports "$tcp_ports" -j RETURN
-                    [ "$udp_enabled" = "yes" ] && [ -n "$udp_ports" ] && insert_rule "$IPT_TABLE" $base $mac_flag -p udp -m multiport $ports_mark --dports "$udp_ports" -j RETURN
 
                     if [ "$policy_mode" = "redirect" ]; then
+                        [ "$tcp_enabled" = "yes" ] && [ -n "$tcp_ports" ] && insert_rule "$IPT_TABLE" $base $mac_flag -p tcp -m multiport --dports "$tcp_ports" -j RETURN
+                        [ "$udp_enabled" = "yes" ] && [ -n "$udp_ports" ] && insert_rule "$IPT_TABLE" $base $mac_flag -p udp -m multiport --dports "$udp_ports" -j RETURN
                         [ "$tcp_enabled" = "yes" ] && append_rule "$IPT_TABLE" $base $mac_flag -p tcp $IPT_JOURNAL_FLAGS
                         [ "$udp_enabled" = "yes" ] && append_rule "$IPT_TABLE" $base $mac_flag -p udp $IPT_JOURNAL_FLAGS
-
                     else
+                        [ "$tcp_enabled" = "yes" ] && [ -n "$tcp_ports" ] && append_rule "$IPT_TABLE" $base $mac_flag -p tcp -m multiport --dports "$tcp_ports" $IPT_JOURNAL_FLAGS
+                        [ "$udp_enabled" = "yes" ] && [ -n "$udp_ports" ] && append_rule "$IPT_TABLE" $base $mac_flag -p udp -m multiport --dports "$udp_ports" $IPT_JOURNAL_FLAGS
                         [ -z "$tcp_ports" ] && [ -z "$udp_ports" ] && insert_rule "$IPT_TABLE" $base $mac_flag -j RETURN
                         [ "$tcp_enabled" = "yes" ] && [ -n "$tcp_ports" ] && append_rule "$IPT_TABLE" $base $mac_flag -p tcp $IPT_JOURNAL_FLAGS
                         [ "$udp_enabled" = "yes" ] && [ -n "$udp_ports" ] && append_rule "$IPT_TABLE" $base $mac_flag -p udp $IPT_JOURNAL_FLAGS


### PR DESCRIPTION
This pull request refactors the `configure_firewall_client` function in `src/backend/firewall.sh` to improve the logic for handling TCP and UDP rules based on the `policy_mode`. The changes streamline the rule insertion process and ensure consistency in how rules are applied.

### Refactoring of firewall rule logic:
* Removed the conditional handling of `ports_mark` for the "bypass" mode, simplifying the logic. (`[src/backend/firewall.shL564-R572](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L564-R572)`)
* Consolidated the rule insertion logic for TCP and UDP ports, ensuring that rules are consistently applied for both "redirect" and other modes. (`[src/backend/firewall.shL564-R572](diffhunk://#diff-b6cd7af8532108f58cbc0e414171b6282d22d83cf2db8e3711fa577a76c57012L564-R572)`)