### PR TITLE
fix: #180 update HTTP settings in NET_KEEP to remove deprecated httpu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # XRAYUI Changelog
 
+## [0.54.1] - 2025-07-23
+
+> _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._
+
+- FIXED: XRAY does not work in the `REDIRECT` mode.
+- FIXED: Unable to save network type `HTTPUpgrade` from the Transport window.
+
 ## [0.54.0] - 2025-07-22
 
 > _Important: Please clear your browser cache (e.g. **Ctrl+F5**) to ensure outdated files are updated._

--- a/src/modules/CommonObjects.ts
+++ b/src/modules/CommonObjects.ts
@@ -558,7 +558,7 @@ const NET_KEEP: Record<string, StreamKey[]> = {
   tcp: ['tcpSettings'],
   kcp: ['kcpSettings'],
   ws: ['wsSettings'],
-  http: ['xhttpSettings', 'httpupgradeSettings'],
+  http: ['xhttpSettings'],
   httpupgrade: ['httpupgradeSettings'],
   grpc: ['grpcSettings'],
   splithttp: ['splithttpSettings']


### PR DESCRIPTION
#180 180
This pull request includes updates to fix bugs, improve firewall configuration logic, and adjust network settings in the XRAYUI project. Key changes include bug fixes mentioned in the changelog, enhanced handling of firewall rules, and a minor adjustment to network type settings.

### Bug Fixes (Changelog Updates):
* Added a new version entry `0.54.1` to `CHANGELOG.md`, documenting fixes for XRAY not working in `REDIRECT` mode and the inability to save the `HTTPUpgrade` network type in the Transport window.

### Firewall Configuration Enhancements:
* Updated `configure_firewall()` in `firewall.sh` to check for and load the `xt_socket` module before adding the transparent `DIVERT` hook. Logs a warning if the module is missing.
* Modified `configure_firewall_client()` in `firewall.sh` to use a broader match for firewall rules (`TPROXY`, `DNAT`, or `REDIRECT`) and removed redundant conditional nesting for cleaner logic.

### Network Type Settings Adjustment:
* Updated `NET_KEEP` in `CommonObjects.ts` to remove `httpupgradeSettings` from the `http` network type and assign it exclusively to the `httpupgrade` type, ensuring proper categorization.