### PR TITLE
fix: `firewall_after_cleanup` hook script never executes — filename mismatch with UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - FIXED: Clicking **Regenerate** for Reality keys did nothing — the private and public key fields stayed empty. The keys are now generated and filled in again. ([#67](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/issues/67))
 - FIXED: With **Prevent DNS leaks** enabled, Wireguard (and other) outbounds could fail with `failed to lookup DNS` errors a few seconds after Xray started. The DNS leak firewall rule was too strict and also blocked Xray's own queries to the router's local DNS resolver. Router-local DNS traffic is now allowed; queries to upstream DNS servers are still blocked, so leak protection is unchanged.
 - ADDED: More GitHub proxy mirrors to choose from in General Options, for more reliable downloads in regions where GitHub is blocked. ([#358](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/pull/358))
+- FIXED: The **After firewall cleanup** hook script set in General Options never ran when Xray stopped, because of a filename mismatch between what the UI saved and what the router looked for. The cleanup hook now runs as expected. Thanks to [@xxhhlk](https://github.com/xxhhlk). ([#353](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/pull/353))
 
 ## [0.67.0] - 2026-05-25
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These scripts should be placed in the `/jffs/xrayui_custom` directory and named 
 
 - `firewall_before_start` - Executed before Xray sets up the firewall rules.
 - `firewall_after_start` - Executed after Xray set up the firewall rules.
-- `firewall_cleanup` - Executed when Xray stops.
+- `firewall_after_cleanup` - Executed when Xray stops.
   Ensure the scripts are executable (`chmod +x <script>`).
 
 ## FAQ

--- a/src/backend/firewall.sh
+++ b/src/backend/firewall.sh
@@ -892,7 +892,7 @@ cleanup_firewall() {
         fi
     fi
 
-    local script="$ADDON_USER_SCRIPTS_DIR/firewall_cleanup"
+    local script="$ADDON_USER_SCRIPTS_DIR/firewall_after_cleanup"
     if [ -x "$script" ]; then
         log_info "Executing user firewall script: $script"
         "$script" "$XRAY_CONFIG_FILE" || log_error "Error executing $script."


### PR DESCRIPTION
## Description

The "After firewall cleanup" hook script saved via the Web UI is never executed because the cleanup function references a different filename than what the UI saves and reads.

## Background

The original implementation (Jan 2025) used 4 mode-specific hook scripts: `firewall_server`, `firewall_server_cleanup`, `firewall_client`, `firewall_client_cleanup`. These were later refactored (Jul 2025, commit `2dac496`) into 3 lifecycle-based hooks: `firewall_before_start`, `firewall_after_start`, `firewall_after_cleanup`, with full UI support in General Options → Hooks.

However, the pre-existing cleanup execution in `firewall.sh` was not updated during this refactoring — it still references the old name `firewall_cleanup` instead of the new `firewall_after_cleanup`.

## Details

When a user writes a cleanup hook in **General Options → Hooks → After firewall cleanup**, the content is saved to:

```
/jffs/xrayui_custom/firewall_after_cleanup
```

However, when the firewall is cleaned up (stop/restart), the code executes:

```
/jffs/xrayui_custom/firewall_cleanup
```

Since these are two different filenames, the user's cleanup script is never run.

## Evidence

| Operation | Filename | File | Line |
|---|---|---|---|
| **Save** from UI | `firewall_after_cleanup` | `src/backend/general_opts.sh` | L174 |
| **Read** for UI display | `firewall_after_cleanup` | `src/backend/response.sh` | L71 |
| **Execute** on cleanup | `firewall_cleanup` | `src/backend/firewall.sh` | L895 |

The other two hooks are consistent:

- `firewall_before_start` — saved, read, and executed under the same name ✅
- `firewall_after_start` — saved, read, and executed under the same name ✅
- `firewall_after_cleanup` — saved and read under this name, but executed as `firewall_cleanup` ❌

## Suggested Fix

In `src/backend/firewall.sh:895`, change:

```sh
local script="$ADDON_USER_SCRIPTS_DIR/firewall_cleanup"
```

to:

```sh
local script="$ADDON_USER_SCRIPTS_DIR/firewall_after_cleanup"
```

## Environment

- XrayUI version: current `main` branch (commit `5b762e2`)
