### PR TITLE
Add gh-proxy.org and danissimo proxy mirrors to General Options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - FIXED: Clicking **Regenerate** for Reality keys did nothing — the private and public key fields stayed empty. The keys are now generated and filled in again. ([#67](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/issues/67))
 - FIXED: With **Prevent DNS leaks** enabled, Wireguard (and other) outbounds could fail with `failed to lookup DNS` errors a few seconds after Xray started. The DNS leak firewall rule was too strict and also blocked Xray's own queries to the router's local DNS resolver. Router-local DNS traffic is now allowed; queries to upstream DNS servers are still blocked, so leak protection is unchanged.
+- ADDED: More GitHub proxy mirrors to choose from in General Options, for more reliable downloads in regions where GitHub is blocked. ([#358](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/pull/358))
 
 ## [0.67.0] - 2026-05-25
 

--- a/src/components/modals/GeneralOptionsModal.vue
+++ b/src/components/modals/GeneralOptionsModal.vue
@@ -387,6 +387,8 @@
 
   const gh_proxies = [
     'https://proxy.lavrush.in/xray/',
+    'https://proxy.danissimo.net/xray/',
+    'https://cdn.gh-proxy.org/',
     'https://ghfast.top/',
     'https://ghproxy.net/',
     'https://jiashu.1win.eu.org/',


### PR DESCRIPTION
Incorporates #358 by @krisavdome (adds `cdn.gh-proxy.org`) and additionally adds `proxy.danissimo.net/xray/` as a GitHub proxy mirror in General Options.

Changelog updated under 0.68.0.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)