### PR TITLE
fix: надёжный restart Xray (ожидание демона, flock, игнор xray api)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # XRAYUI Changelog
 
+## [0.68.3] - 2026-07-30
+
+- FIXED: Restarting Xray from the UI could leave the proxy dead: `stop` cleaned firewall rules, then a blind 4-second wait often wasn't enough for the daemon to exit, so `start` logged `Skipping start` and never restored firewall rules. Concurrent restarts from Save/Restart made this worse. Restart now waits for the real daemon to die (SIGKILL if needed), serializes with `flock`, ignores short-lived `xray api` helpers from UI polling, and restores firewall rules if start is skipped.
+
 ## [0.68.2] - 2026-07-07
 
 - FIXED: Deleting an outbound that a balancer used as its fallback silently left the deleted tag in the generated config, quietly breaking routing. XRAYUI now warns you which balancers still use the outbound as a fallback and asks you to update them first, just like it already does for routing rules. ([#357](https://github.com/DanielLavrushin/asuswrt-merlin-xrayui/issues/357))

--- a/src/backend/_helper.sh
+++ b/src/backend/_helper.sh
@@ -124,6 +124,62 @@ get_proc() {
     echo $(/bin/pidof "$proc_name" 2>/dev/null | awk '{print $NF}')
 }
 
+# Only the Xray daemon (xray -c ...), not helper CLIs like "xray api statsquery"
+# which UI polling spawns and which otherwise break stop/restart logic.
+get_xray_daemon_pid() {
+    local pid cmdline
+    if [ -f "$XRAY_PIDFILE" ]; then
+        pid=$(cat "$XRAY_PIDFILE" 2>/dev/null)
+        if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && [ -r /proc/"$pid"/cmdline ]; then
+            cmdline=$(tr '\0' ' ' </proc/"$pid"/cmdline 2>/dev/null)
+            case "$cmdline" in
+            *" -c "*)
+                echo "$pid"
+                return 0
+                ;;
+            esac
+        fi
+    fi
+    for pid in $(/bin/pidof xray 2>/dev/null); do
+        [ -r /proc/"$pid"/cmdline ] || continue
+        cmdline=$(tr '\0' ' ' </proc/"$pid"/cmdline 2>/dev/null)
+        case "$cmdline" in
+        *" api "*)
+            continue
+            ;;
+        *" -c "*)
+            echo "$pid"
+            return 0
+            ;;
+        esac
+    done
+    return 0
+}
+
+kill_xray_daemon() {
+    local sig="${1:--TERM}"
+    local pid cmdline
+    for pid in $(/bin/pidof xray 2>/dev/null); do
+        [ -r /proc/"$pid"/cmdline ] || continue
+        cmdline=$(tr '\0' ' ' </proc/"$pid"/cmdline 2>/dev/null)
+        case "$cmdline" in
+        *" api "*)
+            continue
+            ;;
+        *)
+            kill "$sig" "$pid" 2>/dev/null
+            ;;
+        esac
+    done
+    if [ -n "$(get_xray_daemon_pid)" ]; then
+        if [ "$sig" = "-9" ] || [ "$sig" = "-KILL" ]; then
+            killall -9 xray 2>/dev/null
+        else
+            killall xray 2>/dev/null
+        fi
+    fi
+}
+
 get_proc_uptime() {
     local pid=$(pidof "$1")
 

--- a/src/backend/control.sh
+++ b/src/backend/control.sh
@@ -7,11 +7,30 @@ start() {
 
     cleanup_stale_asdfiles
 
-    # Prevent duplicate starts - check if Xray is already running
-    local existing_pid=$(get_proc "xray")
+    # Prevent duplicate starts - check if Xray *daemon* is already running
+    # (ignore short-lived "xray api ..." helpers from UI polling)
+    local existing_pid=$(get_xray_daemon_pid)
     if [ -n "$existing_pid" ]; then
-        log_warn "Xray is already running (PID: $existing_pid). Skipping start."
-        return 0
+        if [ "${FORCE_RESTART:-false}" = "true" ]; then
+            local tries=0
+            while [ -n "$existing_pid" ] && [ "$tries" -lt 5 ]; do
+                log_warn "Xray daemon still running (PID: $existing_pid) during restart; forcing stop ($tries/5)"
+                kill_xray_daemon -9
+                rm -f "$XRAY_PIDFILE"
+                sleep 1
+                existing_pid=$(get_xray_daemon_pid)
+                tries=$((tries + 1))
+            done
+            if [ -n "$existing_pid" ]; then
+                log_error "Failed to force-stop Xray daemon (PID: $existing_pid)"
+                return 1
+            fi
+        else
+            log_warn "Xray is already running (PID: $existing_pid). Skipping start."
+            # Safety: if firewall was cleaned by a concurrent stop/restart, restore rules
+            configure_firewall
+            return 0
+        fi
     fi
 
     local skip_test="${skip_test:-false}"
@@ -118,10 +137,37 @@ stop() {
 
     update_loading_progress "Stopping $ADDON_TITLE"
 
-    killall xray
+    if [ -n "$(get_xray_daemon_pid)" ]; then
+        kill_xray_daemon -TERM
+
+        # Wait up to ~10s for daemon exit (ignore "xray api" helpers)
+        local i=0
+        while [ -n "$(get_xray_daemon_pid)" ] && [ "$i" -lt 10 ]; do
+            log_debug "Waiting for Xray to stop... ($i/10)"
+            update_loading_progress "Waiting for Xray to stop... ($i/10)"
+            sleep 1
+            i=$((i + 1))
+        done
+
+        if [ -n "$(get_xray_daemon_pid)" ]; then
+            log_warn "Xray did not stop in time, sending SIGKILL"
+            kill_xray_daemon -9
+            sleep 1
+        fi
+    fi
+
+    # Sweep leftover helpers so they cannot race the upcoming start()
+    killall -9 xray 2>/dev/null
+
+    if [ -n "$(get_xray_daemon_pid)" ]; then
+        log_error "Xray daemon is still running after SIGKILL"
+    fi
+
     if [ -f "$XRAY_PIDFILE" ]; then
         rm -f "$XRAY_PIDFILE"
         log_info "PID file $XRAY_PIDFILE removed successfully."
+    else
+        rm -f "$XRAY_PIDFILE"
     fi
 
     cleanup_firewall
@@ -130,18 +176,32 @@ stop() {
 }
 
 restart() {
+    # Serialize restarts atomically. Wait (do not skip) so UI double-fires
+    # and apply+restart still complete instead of aborting every other click.
+    local RESTART_LOCK="/tmp/xrayui_restart.lock"
+    local RESTART_FD=387
+    eval exec "$RESTART_FD>$RESTART_LOCK"
+    if ! flock -n "$RESTART_FD"; then
+        log_warn "Restart already in progress; waiting for lock..."
+        update_loading_progress "Restart already in progress; waiting..."
+        flock -x "$RESTART_FD"
+    fi
+
     log_info "Restarting $ADDON_TITLE"
 
     POST_RESTART_DNSMASQ="true"
 
     stop
-    log_debug "Waiting for Xray to stop..."
-    sleep 4
-    start
+    # stop() already waits for daemon death / SIGKILL; no blind sleep needed
+    FORCE_RESTART=true start
+    local start_rc=$?
 
     if [ "$POST_RESTART_DNSMASQ" = "true" ]; then
         dnsmasq_restart
     fi
 
     POST_RESTART_DNSMASQ="false"
+
+    flock -u "$RESTART_FD"
+    return "$start_rc"
 }

--- a/src/backend/startup.sh
+++ b/src/backend/startup.sh
@@ -30,7 +30,7 @@ startup() {
     remount_ui
     cron_jobs_add
 
-    local xray_pid=$(get_proc "xray")
+    local xray_pid=$(get_xray_daemon_pid)
 
     if [ "$(am_settings_get xray_startup)" = "y" ]; then
         log_ok "Xray service is enabled by XRAYUI. Starting Xray service..."


### PR DESCRIPTION
## Summary

- После Restart прокси мог остаться мёртвым: `stop()` сносил firewall, затем слепой `sleep 4` часто не хватало, чтобы демон успел завершиться, и `start()` писал `Skipping start` **без** `configure_firewall`. UI при этом показывал success (короткий путь: cleanup → dnsmasq → готово, без Testing / Waiting / Configuring firewall).
- Параллельные Save/Restart через `service-event … &` усугубляли гонку: один успевал стартовать, второй делал skip.
- Поллинг UI запускает `xray api statsquery`; `pidof xray` принимал эти хелперы за демон, из‑за чего force-stop мог оборвать нормальный restart (`Failed to force-stop` с новым PID).

## Changes

- В `stop()` ждём реальный демон до ~10 с, при необходимости `SIGKILL`; перед cleanup добиваем оставшиеся процессы `xray`.
- Отличаем демон (`xray -c …`) от хелперов (`xray api …`) через `get_xray_daemon_pid` / `kill_xray_daemon`.
- Сериализуем `restart()` через `flock` (ждём, не skip); убираем слепой `sleep 4`; вызываем `FORCE_RESTART=true start`.
- Если start пропускается при уже запущенном демоне — на всякий случай вызываем `configure_firewall`.

## Test plan

- [ ] Один Restart из UI → полный прогресс: Testing → Waiting N/10 → Configuring firewall → success; прокси работает.
- [ ] Несколько Restart подряд (и Save + Restart) → нет короткого «success» без firewall; в syslog нет `Skipping start` / `Failed to force-stop` из‑за `xray api`.
- [ ] С открытой панелью (поллинг connection/clients) restart всё равно поднимает демон.
- [ ] `grep XRAYUI /tmp/syslog.log` вокруг restart показывает старт демона и configure firewall, а не только skip.