### PR TITLE
fix: allow IPv6 addresses in inbound listen fields

### DIFF
--- a/src/components/SimpleMode.vue
+++ b/src/components/SimpleMode.vue
@@ -7,10 +7,9 @@
         <hint v-html="$t('com.InboundCommon.hint_listen')"></hint>
         <input
           type="text"
-          maxlength="15"
           class="input_20_table"
           v-model="inbound.listen"
-          onkeypress="return validator.isIPAddr(this, event);"
+          @keypress="filterIPAddressKey"
           autocomplete="off"
           autocorrect="off"
           autocapitalize="off"
@@ -99,6 +98,7 @@
   import { XrayVmessClientObject } from '@/modules/ClientsObjects';
   import { IProtocolType } from '@/modules/Interfaces';
   import { XrayRoutingRuleObject } from '@/modules/CommonObjects';
+  import { filterIPAddressKey } from '@/modules/validators';
 
   export default defineComponent({
     name: 'SimpleMode',
@@ -256,7 +256,8 @@
         proxySubscribeUrl,
         flows: ['xtls-rprx-vision', 'xtls-rprx-vision-udp443'],
         show_sniffing,
-        isLocked
+        isLocked,
+        filterIPAddressKey
       };
     }
   });

--- a/src/components/inbounds/InboundCommon.vue
+++ b/src/components/inbounds/InboundCommon.vue
@@ -17,10 +17,9 @@
     <td>
       <input
         type="text"
-        maxlength="15"
         class="input_20_table"
         v-model="inbound.listen"
-        onkeypress="return validator.isIPAddr(this, event);"
+        @keypress="filterIPAddressKey"
         autocomplete="off"
         autocorrect="off"
         autocapitalize="off"
@@ -50,6 +49,7 @@
   import { IProtocolType } from '@/modules/Interfaces';
   import engine from '@/modules/Engine';
   import Hint from '@main/Hint.vue';
+  import { filterIPAddressKey } from '@/modules/validators';
 
   export default defineComponent({
     name: 'InboundCommon',
@@ -73,7 +73,8 @@
         allocateModal,
         inbound,
         engine,
-        show_allocate
+        show_allocate,
+        filterIPAddressKey
       };
     }
   });

--- a/src/components/inbounds/SocksInbound.vue
+++ b/src/components/inbounds/SocksInbound.vue
@@ -38,7 +38,7 @@
             <hint> When `UDP` is enabled, Xray needs to know the local IP address. The default value is `127.0.0.1`. </hint>
           </th>
           <td>
-            <input type="text" maxlength="15" class="input_20_table" v-model="inbound.settings.ip" onkeypress="return validator.isIPAddr(this, event);" autocomplete="off" autocorrect="off" autocapitalize="off" />
+            <input type="text" class="input_20_table" v-model="inbound.settings.ip" @keypress="filterIPAddressKey" autocomplete="off" autocorrect="off" autocapitalize="off" />
             <span class="hint-color">default: 127.0.0.1</span>
           </td>
         </tr>
@@ -56,6 +56,7 @@
   import { XrayInboundObject } from '@/modules/InboundObjects';
   import { XraySocksInboundObject } from '@/modules/InboundObjects';
   import Hint from '@main/Hint.vue';
+  import { filterIPAddressKey } from '@/modules/validators';
 
   export default defineComponent({
     name: 'SocksInbound',
@@ -71,7 +72,8 @@
       const inbound = ref<XrayInboundObject<XraySocksInboundObject>>(props.inbound ?? new XrayInboundObject<XraySocksInboundObject>(XrayProtocol.SOCKS, new XraySocksInboundObject()));
       return {
         inbound,
-        authentications: ['noauth', 'password']
+        authentications: ['noauth', 'password'],
+        filterIPAddressKey
       };
     }
   });

--- a/src/modules/validators.ts
+++ b/src/modules/validators.ts
@@ -12,7 +12,7 @@
  *   - 0-9           digits
  *   - .             IPv4 dotted notation
  *   - :             IPv6 segment separator
- *   - [ ]           Xray requires IPv6 addresses wrapped as [::]
+ *   - [ ]           Xray accepts IPv6 addresses wrapped as [::] (brackets optional)
  *   - a-f / A-F     IPv6 hexadecimal (compressed) notation
  * Every non-printable key (Enter, arrows, Backspace, …) is passed through, and
  * Ctrl/Cmd shortcuts (copy, paste, select-all) are allowed. Alt/AltGr
@@ -27,7 +27,10 @@ export const filterIPAddressKey = (event: KeyboardEvent): void => {
   }
 
   // Pass through every non-printable key (Enter, arrows, editing keys, …).
-  if (event.key.length !== 1) {
+  // Use code-point count, not UTF-16 length: an astral character like an emoji
+  // is one code point but two UTF-16 units, so `event.key.length` would wrongly
+  // treat it as a control key and let it bypass the allowlist below.
+  if ([...event.key].length !== 1) {
     return;
   }
 

--- a/src/modules/validators.ts
+++ b/src/modules/validators.ts
@@ -38,7 +38,7 @@ export const filterIPAddressKey = (event: KeyboardEvent): void => {
   }
 
   // Allow only IPv4 / IPv6 address characters.
-  if (!/^[0-9.:\[\]a-fA-F]$/.test(key)) {
+  if (!/^[0-9.:[\]a-fA-F]$/.test(key)) {
     event.preventDefault();
   }
 };

--- a/src/modules/validators.ts
+++ b/src/modules/validators.ts
@@ -1,0 +1,44 @@
+/**
+ * Keypress filter for IP address inputs.
+ *
+ * Inbound fields such as `listen` originally used ASUS firmware's global
+ * `validator.isIPAddr`, which only allows digits and dots. That blocks the
+ * colon, brackets and hexadecimal letters required by IPv6 addresses, making
+ * it impossible to type an IPv6 listen address in the UI (e.g. `[::]`,
+ * `[2001:db8::1]`).
+ *
+ * This filter allows every character needed for IPv4 and IPv6 addresses and
+ * prevents the default action for anything else:
+ *   - 0-9           digits
+ *   - .             IPv4 dotted notation
+ *   - :             IPv6 segment separator
+ *   - [ ]           Xray requires IPv6 addresses wrapped as [::]
+ *   - a-f / A-F     IPv6 hexadecimal (compressed) notation
+ * Control keys (Backspace, arrows, Home/End, Tab) and key combinations with a
+ * modifier (copy/paste, etc.) are always allowed.
+ */
+export const filterIPAddressKey = (event: KeyboardEvent): void => {
+  if (event.ctrlKey || event.altKey || event.metaKey) {
+    return; // Allow Ctrl / Cmd / Alt combinations (copy, paste, etc.)
+  }
+
+  const key = event.key;
+
+  // Non-character editing keys: let the browser handle them.
+  if (
+    key === 'Backspace' ||
+    key === 'Delete' ||
+    key === 'ArrowLeft' ||
+    key === 'ArrowRight' ||
+    key === 'Home' ||
+    key === 'End' ||
+    key === 'Tab'
+  ) {
+    return;
+  }
+
+  // Allow only IPv4 / IPv6 address characters.
+  if (!/^[0-9.:\[\]a-fA-F]$/.test(key)) {
+    event.preventDefault();
+  }
+};

--- a/src/modules/validators.ts
+++ b/src/modules/validators.ts
@@ -14,31 +14,25 @@
  *   - :             IPv6 segment separator
  *   - [ ]           Xray requires IPv6 addresses wrapped as [::]
  *   - a-f / A-F     IPv6 hexadecimal (compressed) notation
- * Control keys (Backspace, arrows, Home/End, Tab) and key combinations with a
- * modifier (copy/paste, etc.) are always allowed.
+ * Every non-printable key (Enter, arrows, Backspace, …) is passed through, and
+ * Ctrl/Cmd shortcuts (copy, paste, select-all) are allowed. Alt/AltGr
+ * combinations are validated like normal input so they cannot inject
+ * characters outside the IPv4/IPv6 character set.
  */
 export const filterIPAddressKey = (event: KeyboardEvent): void => {
-  if (event.ctrlKey || event.altKey || event.metaKey) {
-    return; // Allow Ctrl / Cmd / Alt combinations (copy, paste, etc.)
-  }
-
-  const key = event.key;
-
-  // Non-character editing keys: let the browser handle them.
-  if (
-    key === 'Backspace' ||
-    key === 'Delete' ||
-    key === 'ArrowLeft' ||
-    key === 'ArrowRight' ||
-    key === 'Home' ||
-    key === 'End' ||
-    key === 'Tab'
-  ) {
+  // Allow Ctrl/Cmd shortcuts, but not Alt/AltGr (reported as Ctrl+Alt) which
+  // can emit characters and must be validated.
+  if ((event.ctrlKey || event.metaKey) && !event.altKey) {
     return;
   }
 
-  // Allow only IPv4 / IPv6 address characters.
-  if (!/^[0-9.:[\]a-fA-F]$/.test(key)) {
+  // Pass through every non-printable key (Enter, arrows, editing keys, …).
+  if (event.key.length !== 1) {
+    return;
+  }
+
+  // Block any character that is not part of an IPv4/IPv6 address.
+  if (!/^[0-9.:[\]a-fA-F]$/.test(event.key)) {
     event.preventDefault();
   }
 };


### PR DESCRIPTION
Inbound "Listen" and SOCKS "Local IP address" fields rejected IPv6 addresses (e.g. `::`, `2001:db8::1`): the inputs used `maxlength="15"` and the firmware's IPv4-only `validator.isIPAddr` on keypress.

Changes:
- `src/modules/validators.ts`: new `filterIPAddressKey` filter allowing IPv6 characters (0-9 . : [ ] a-f A-F) and control keys.
- SimpleMode / InboundCommon / SocksInbound: replaced the IPv4-only   keypress handler with `filterIPAddressKey`.

Verified with `pnpm build` + `vue-tsc` (no new errors) and on-device test creating an inbound with `::1` listen.