### PR TITLE
fix: normalize CRLF line endings when inlining shell imports

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
-text eol=LF;
+* text=auto eol=lf
+
+*.sh text eol=lf
+*.conf text eol=lf
+
+*.png binary
+*.ico binary
+*.gz binary
+*.zip binary
+*.dat binary

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ function inlineShellImports(scriptPath, visited = new Set(), isRoot = true) {
   }
   visited.add(scriptPath);
 
-  let content = fs.readFileSync(scriptPath, 'utf8');
+  let content = fs.readFileSync(scriptPath, 'utf8').replace(/\r\n/g, '\n');
   const dirOfScript = dirname(scriptPath);
 
   const lines = content.split('\n');

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,7 +34,7 @@ function inlineShellImports(scriptPath, visited = new Set(), isRoot = true) {
   }
   visited.add(scriptPath);
 
-  let content = fs.readFileSync(scriptPath, 'utf8').replace(/\r\n/g, '\n');
+  let content = fs.readFileSync(scriptPath, 'utf8').replaceAll('\r\n', '\n');
   const dirOfScript = dirname(scriptPath);
 
   const lines = content.split('\n');


### PR DESCRIPTION
fix: normalize CRLF line endings when inlining shell imports `pnpm watch` produced a broken `dist/xrayui` on Windows: the script kept un-inlined `import` lines (`import: not found` at runtime) and the entrypoint failed to start.

Root cause: `inlineShellImports()` matches `^import\s+(.+)$`, but with CRLF line endings `$` never matches before `\r`, so imports were skipped.

Fix: normalize `\r\n` to `\n` before scanning.

Verified: the built script is fully inlined and runs correctly on the router.