### PR TITLE
chore: allow custom SFTP port in vite.sync.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 SFTP_ROUTER=
 SFTP_USERNAME=
 SFTP_PASSWORD=
+# SSH/SFTP port on the router (default: 22)
+SFTP_PORT=

--- a/vite.sync.js
+++ b/vite.sync.js
@@ -9,7 +9,7 @@ async function uploadFiles() {
   try {
     await sftp.connect({
       host: process.env.SFTP_ROUTER,
-      port: parseInt(process.env.SFTP_PORT, 10) || 22,
+      port: Number.parseInt(process.env.SFTP_PORT, 10) || 22,
       username: process.env.SFTP_USERNAME,
       password: process.env.SFTP_PASSWORD,
       readyTimeout: 3000

--- a/vite.sync.js
+++ b/vite.sync.js
@@ -9,7 +9,7 @@ async function uploadFiles() {
   try {
     await sftp.connect({
       host: process.env.SFTP_ROUTER,
-      port: 22,
+      port: parseInt(process.env.SFTP_PORT, 10) || 22,
       username: process.env.SFTP_USERNAME,
       password: process.env.SFTP_PASSWORD,
       readyTimeout: 3000


### PR DESCRIPTION
vite.sync.js hardcoded port 22 even though host/user/password are all read from env.
Routers with a non-default SSH port (common for security) could not use the dev sync workflow.

Changes:
- `vite.sync.js`: read `SFTP_PORT` env var, fall back to 22.
- `.env.example`: document the new variable.